### PR TITLE
Adapt to latest CoreDSL 2 specification

### DIFF
--- a/RISCVBase.core_desc
+++ b/RISCVBase.core_desc
@@ -1,11 +1,11 @@
 InstructionSet RISCVBase {
     architectural_state {
-        unsigned XLEN;
-        unsigned CSR_SIZE=4096;
-        unsigned fence=0;
-        unsigned fencei=1;
-        unsigned fencevmal=2;
-        unsigned fencevmau=3;
+        unsigned int XLEN;
+        unsigned int CSR_SIZE=4096;
+        unsigned int fence=0;
+        unsigned int fencei=1;
+        unsigned int fencevmal=2;
+        unsigned int fencevmau=3;
         // core registers
         register unsigned<XLEN>  X[32];
         register unsigned<XLEN>  PC [[is_pc]];

--- a/RISCVBase.core_desc
+++ b/RISCVBase.core_desc
@@ -52,8 +52,8 @@ InstructionSet RISCVBase {
     }
 
     functions {
-    	extern void raise(int irq, int mcause);
-    	extern void leave(int priv_lvl);
-    	extern void wait(int flag);
+        extern void raise(int irq, int mcause);
+        extern void leave(int priv_lvl);
+        extern void wait(int flag);
     }
 }

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -3,26 +3,26 @@ import "RISCVBase.core_desc"
 InstructionSet RV32I extends RISCVBase {
     instructions {
         LUI{
-            encoding: imm[31:12] :: rd[4:0] :: 0b0110111;
-            args_disass: "{name(rd)}, {imm:#05x}";
+            encoding: imm[31:12] :: rd[4:0] :: 7'b0110111;
+            assembly: "{name(rd)}, {imm:#05x}";
             behavior: if(rd!=0) X[rd] = (signed<XLEN>)imm;
         }
         AUIPC{
-            encoding: imm[31:12] :: rd[4:0] :: 0b0010111;
-            args_disass: "{name(rd)}, {imm:#08x}";
+            encoding: imm[31:12] :: rd[4:0] :: 7'b0010111;
+            assembly: "{name(rd)}, {imm:#08x}";
             behavior: if(rd!=0) X[rd] = PC+(signed<XLEN>)imm;
         }
         JAL[[no_cont]]{
-            encoding: imm[20:20] :: imm[10:1] :: imm[11:11] :: imm[19:12] :: rd[4:0] :: 0b1101111;
-            args_disass: "{name(rd)}, {imm:#0x}";
+            encoding: imm[20:20] :: imm[10:1] :: imm[11:11] :: imm[19:12] :: rd[4:0] :: 7'b1101111;
+            assembly: "{name(rd)}, {imm:#0x}";
             behavior: {
                 if(rd!=0) X[rd] = PC+4;
                 PC=PC+(signed<21>)imm;
             }
         }
         JALR[[no_cont]]{
-            encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1100111;
-            args_disass: "{name(rd)}, {name(rs1)}, {imm:#0x}";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1100111;
+            assembly: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
                 signed<XLEN> new_pc = X[rs1] + (signed<12>)imm;
                 signed<XLEN> align = new_pc & 0x2;
@@ -35,46 +35,46 @@ InstructionSet RV32I extends RISCVBase {
             }
         }
         BEQ[[no_cont]] [[cond]]{
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b000 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if(X[rs1]==X[rs2]) PC = PC + (signed<13>)imm;
         }
         BNE[[no_cont]] [[cond]]{
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b001 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if(X[rs1]!=X[rs2]) PC = PC + (signed<13>)imm;
         }
         BLT[[no_cont]] [[cond]]{
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b100 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if((signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2]) PC = PC + (signed<13>)imm;
         }
         BGE[[no_cont]] [[cond]] {
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b101 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if((signed<XLEN>)X[rs1] >= (signed<XLEN>)X[rs2]) PC = PC + (signed<13>)imm;
         }
         BLTU[[no_cont]] [[cond]] {
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b110 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if(X[rs1]<X[rs2]) PC = PC + (signed<13>)imm;
         }
         BGEU[[no_cont]] [[cond]] {
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b111 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if(X[rs1]>=X[rs2]) PC = PC + (signed<13>)imm;
         }
         LB {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0000011;
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 signed<8> res = (signed<8>)MEM[X[rs1] + (signed<12>)imm];
                 if(rd!=0) X[rd]=res;
             }
         }
         LH {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0000011;
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<16> res = (signed<16>)MEM[X[rs1] + (signed<12>)imm];
@@ -82,8 +82,8 @@ InstructionSet RV32I extends RISCVBase {
              }
         }
         LW {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0000011;
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<32> res = (signed<32>)MEM[X[rs1] + (signed<12>)imm];
@@ -91,16 +91,16 @@ InstructionSet RV32I extends RISCVBase {
             }
         }
         LBU {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0000011;
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<8> res = (unsigned<8>)MEM[X[rs1] + (signed<12>)imm];
                 if(rd!=0) X[rd]=res;
             }
         }
         LHU {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0000011;
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 unsigned<16> res = (unsigned<16>)MEM[X[rs1] + (signed<12>)imm];
@@ -108,59 +108,59 @@ InstructionSet RV32I extends RISCVBase {
             }
         }
         SB {
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b000 :: imm[4:0] :: 0b0100011;
-            args_disass:"{name(rs2)}, {imm}({name(rs1)})";
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: imm[4:0] :: 7'b0100011;
+            assembly: "{name(rs2)}, {imm}({name(rs1)})";
             behavior: MEM[X[rs1] + (signed<12>)imm] = (char)X[rs2];
         }
         SH {
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b001 :: imm[4:0] :: 0b0100011;
-            args_disass:"{name(rs2)}, {imm}({name(rs1)})";
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: imm[4:0] :: 7'b0100011;
+            assembly: "{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
                 MEM[store_address] = (short)X[rs2];
             }
         }
         SW {
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: imm[4:0] :: 0b0100011;
-            args_disass:"{name(rs2)}, {imm}({name(rs1)})";
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: imm[4:0] :: 7'b0100011;
+            assembly: "{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
                 MEM[store_address] = X[rs2];
             }
         }
         ADDI {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if(rd != 0) X[rd] = X[rs1] + (signed<12>)imm;
         }
         SLTI {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] < (signed<12>)imm? 1 : 0;
         }
         SLTIU {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = (X[rs1] < (unsigned<XLEN>)((signed<12>)imm))? 1 : 0;
         }
         XORI {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if(rd != 0) X[rd] = X[rs1] ^ (signed<12>)imm;
         }
         ORI {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if(rd != 0) X[rd] = X[rs1] | (signed<12>)imm;
         }
         ANDI {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if(rd != 0) X[rd] = X[rs1] & (signed<12>)imm;
         }
         SLLI {
-            encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(shamt > 31){
                 raise(0,0);
             } else {
@@ -168,8 +168,8 @@ InstructionSet RV32I extends RISCVBase {
             }
         }
         SRLI {
-            encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(shamt > 31){
                 raise(0,0);
             } else {
@@ -177,8 +177,8 @@ InstructionSet RV32I extends RISCVBase {
             }
         }
         SRAI {
-            encoding: 0b0100000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            encoding: 7'b0100000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(shamt > 31){
                 raise(0,0);
             } else {
@@ -186,87 +186,87 @@ InstructionSet RV32I extends RISCVBase {
             }
         }
         ADD {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd != 0) X[rd] = X[rs1] + X[rs2];
         }
         SUB {
-            encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd != 0) X[rd] = X[rs1] - X[rs2];
         }
         SLL {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd != 0) X[rd] = X[rs1]<< (X[rs2]&(XLEN-1));
         }
         SLT {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2]? 1 : 0;
         }
         SLTU {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = (unsigned<XLEN>)X[rs1] < (unsigned<XLEN>)X[rs2]? 1 : 0;
         }
         XOR {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd != 0) X[rd] = X[rs1] ^ X[rs2];
         }
         SRL {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd != 0) X[rd] = X[rs1] >> (X[rs2]&(XLEN-1));
         }
         SRA {
-            encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> (X[rs2]&(XLEN-1));
         }
         OR {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd != 0) X[rd] = X[rs1] | X[rs2];
         }
         AND {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd != 0) X[rd] = X[rs1] & X[rs2];
         }
         FENCE {
-            encoding: fm[3:0] :: pred[3:0] :: succ[3:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0001111;
-            args_disass:"{pred}, {succ} ({fm} , {name(rs1)}, {name(rd)})";
+            encoding: fm[3:0] :: pred[3:0] :: succ[3:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0001111;
+            assembly: "{pred}, {succ} ({fm} , {name(rs1)}, {name(rd)})";
             behavior: FENCE[fence] = pred<<4 | succ;
         }
         ECALL[[no_cont]] {
-            encoding: 0b000000000000 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 0b000000000000 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: raise(0, 11);
         }
         EBREAK[[no_cont]] {
-            encoding: 0b000000000001 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 0b000000000001 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: raise(0, 3);
         }
         URET[[no_cont]] {
-            encoding: 0b0000000 :: 0b00010 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 7'b0000000 :: 5'b00010 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: leave(0);
         }
         SRET[[no_cont]]  {
-            encoding: 0b0001000 :: 0b00010 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 7'b0001000 :: 5'b00010 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: leave(1);
         }
         MRET[[no_cont]] {
-            encoding: 0b0011000 :: 0b00010 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 7'b0011000 :: 5'b00010 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: leave(3);
         }
         WFI  {
-            encoding: 0b0001000 :: 0b00101 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 7'b0001000 :: 5'b00101 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: wait(1);
         }
         CSRRW {
-            encoding: csr[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {name(rs1)}";
+            encoding: csr[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1110011;
+            assembly: "{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
                 unsigned<XLEN> xrs1 = X[rs1];
                 if(rd!=0){
@@ -280,8 +280,8 @@ InstructionSet RV32I extends RISCVBase {
             }
         }
         CSRRS {
-            encoding: csr[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {name(rs1)}";
+            encoding: csr[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1110011;
+            assembly: "{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 unsigned<XLEN> xrs1 = X[rs1];
@@ -290,8 +290,8 @@ InstructionSet RV32I extends RISCVBase {
             }
         }
         CSRRC {
-            encoding: csr[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {name(rs1)}";
+            encoding: csr[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b1110011;
+            assembly: "{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 unsigned<XLEN> xrs1 = X[rs1];
@@ -300,8 +300,8 @@ InstructionSet RV32I extends RISCVBase {
             }
         }
         CSRRWI {
-            encoding: csr[11:0] :: zimm[4:0] :: 0b101 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
+            encoding: csr[11:0] :: zimm[4:0] :: 3'b101 :: rd[4:0] :: 7'b1110011;
+            assembly: "{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 CSR[csr] = (unsigned<XLEN>)zimm;
@@ -309,8 +309,8 @@ InstructionSet RV32I extends RISCVBase {
             }
         }
         CSRRSI {
-            encoding: csr[11:0] :: zimm[4:0] :: 0b110 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
+            encoding: csr[11:0] :: zimm[4:0] :: 3'b110 :: rd[4:0] :: 7'b1110011;
+            assembly: "{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 if(zimm!=0) CSR[csr] = xrd | (unsigned<XLEN>)zimm;
@@ -318,8 +318,8 @@ InstructionSet RV32I extends RISCVBase {
             }
         }
         CSRRCI {
-            encoding: csr[11:0] :: zimm[4:0] :: 0b111 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
+            encoding: csr[11:0] :: zimm[4:0] :: 3'b111 :: rd[4:0] :: 7'b1110011;
+            assembly: "{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 if(zimm!=0) CSR[csr] = xrd & ~((unsigned<XLEN>)zimm);
@@ -332,13 +332,13 @@ InstructionSet RV32I extends RISCVBase {
 InstructionSet Zifencei extends RISCVBase {
     instructions {
         FENCE_I[[flush]] {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0001111 ;
-            args_disass:"{name(rs1)}, {name(rd)}, {imm}";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0001111 ;
+            assembly: "{name(rs1)}, {name(rd)}, {imm}";
             behavior: FENCE[fencei] = imm;
         }
         SFENCE_VMA {
-            encoding: 0b0001001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: 0b00000 :: 0b1110011;
-            args_disass:"{name(rs2)}, {rs1}";
+            encoding: 7'b0001001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: 5'b00000 :: 7'b1110011;
+            assembly: "{name(rs2)}, {rs1}";
             behavior: {
                 FENCE[fencevmal] = (unsigned)rs1;
                 FENCE[fencevmau] = (unsigned)rs2;

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -1,8 +1,7 @@
 import "RISCVBase.core_desc"
 
 InstructionSet RV32I extends RISCVBase {
-     
-    instructions { 
+    instructions {
         LUI{
             encoding: imm[31:12] :: rd[4:0] :: 0b0110111;
             args_disass: "{name(rd)}, {imm:#05x}";
@@ -17,22 +16,22 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[20:20] :: imm[10:1] :: imm[11:11] :: imm[19:12] :: rd[4:0] :: 0b1101111;
             args_disass: "{name(rd)}, {imm:#0x}";
             behavior: {
-            	if(rd!=0) X[rd] = PC+4;
-            	PC=PC+(signed<21>)imm;
-        	}
+                if(rd!=0) X[rd] = PC+4;
+                PC=PC+(signed<21>)imm;
+            }
         }
         JALR[[no_cont]]{
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1100111;
             args_disass: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
-	            signed<XLEN> new_pc = X[rs1] + (signed<12>)imm;
-	            signed<XLEN> align = new_pc & 0x2;
-	            if(align != 0){
-	                raise(0, 0);
-	            } else {
-	                if(rd!=0) X[rd] = PC+4;
-	                PC=new_pc & ~0x1;
-	            }	            
+                signed<XLEN> new_pc = X[rs1] + (signed<12>)imm;
+                signed<XLEN> align = new_pc & 0x2;
+                if(align != 0){
+                    raise(0, 0);
+                } else {
+                    if(rd!=0) X[rd] = PC+4;
+                    PC=new_pc & ~0x1;
+                }
             }
         }
         BEQ[[no_cont]] [[cond]]{
@@ -80,7 +79,7 @@ InstructionSet RV32I extends RISCVBase {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<16> res = (signed<16>)MEM[X[rs1] + (signed<12>)imm];
                 if(rd!=0) X[rd]=res;
-             }    
+             }
         }
         LW {
             encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0000011;
@@ -89,7 +88,7 @@ InstructionSet RV32I extends RISCVBase {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<32> res = (signed<32>)MEM[X[rs1] + (signed<12>)imm];
                 if(rd!=0) X[rd]=(unsigned<32>)res;
-            } 
+            }
         }
         LBU {
             encoding: imm[11:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0000011;
@@ -116,7 +115,7 @@ InstructionSet RV32I extends RISCVBase {
         SH {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b001 :: imm[4:0] :: 0b0100011;
             args_disass:"{name(rs2)}, {imm}({name(rs1)})";
-            behavior: { 
+            behavior: {
                 unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
                 MEM[store_address] = (short)X[rs2];
             }
@@ -209,7 +208,7 @@ InstructionSet RV32I extends RISCVBase {
         SLTU {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-           	behavior: if (rd != 0) X[rd] = (unsigned<XLEN>)X[rs1] < (unsigned<XLEN>)X[rs2]? 1 : 0;
+            behavior: if (rd != 0) X[rd] = (unsigned<XLEN>)X[rs1] < (unsigned<XLEN>)X[rs2]? 1 : 0;
         }
         XOR {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0110011;
@@ -269,35 +268,35 @@ InstructionSet RV32I extends RISCVBase {
             encoding: csr[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
-	            unsigned<XLEN> xrs1 = X[rs1];
-	            if(rd!=0){
-	                unsigned<XLEN> xrd = CSR[csr];
-	                CSR[csr] = xrs1; 
-	                // make sure Xrd is updated once CSR write succeeds
-	                X[rd] = xrd;
-	            } else {
-	                CSR[csr] = xrs1;
-	            }
+                unsigned<XLEN> xrs1 = X[rs1];
+                if(rd!=0){
+                    unsigned<XLEN> xrd = CSR[csr];
+                    CSR[csr] = xrs1;
+                    // make sure Xrd is updated once CSR write succeeds
+                    X[rd] = xrd;
+                } else {
+                    CSR[csr] = xrs1;
+                }
             }
         }
         CSRRS {
             encoding: csr[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
-	            unsigned<XLEN> xrd = CSR[csr];
-	            unsigned<XLEN> xrs1 = X[rs1];
-                if(rs1!=0) CSR[csr] = xrd | xrs1;    
-	            if(rd!=0) X[rd] = xrd;
+                unsigned<XLEN> xrd = CSR[csr];
+                unsigned<XLEN> xrs1 = X[rs1];
+                if(rs1!=0) CSR[csr] = xrd | xrs1;
+                if(rd!=0) X[rd] = xrd;
             }
         }
         CSRRC {
             encoding: csr[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
-	            unsigned<XLEN> xrd = CSR[csr];
-	            unsigned<XLEN> xrs1 = X[rs1];
+                unsigned<XLEN> xrd = CSR[csr];
+                unsigned<XLEN> xrs1 = X[rs1];
                 if(rs1!=0) CSR[csr] = xrd & ~xrs1;
-	            if(rd!=0) X[rd] = xrd;
+                if(rd!=0) X[rd] = xrd;
             }
         }
         CSRRWI {
@@ -305,7 +304,7 @@ InstructionSet RV32I extends RISCVBase {
             args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
-	            CSR[csr] = (unsigned<XLEN>)zimm;    
+                CSR[csr] = (unsigned<XLEN>)zimm;
                 if(rd!=0) X[rd] = xrd;
             }
         }
@@ -313,20 +312,20 @@ InstructionSet RV32I extends RISCVBase {
             encoding: csr[11:0] :: zimm[4:0] :: 0b110 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
-	            unsigned<XLEN> xrd = CSR[csr];
-	            if(zimm!=0) CSR[csr] = xrd | (unsigned<XLEN>)zimm;
-	            if(rd!=0) X[rd] = xrd;
+                unsigned<XLEN> xrd = CSR[csr];
+                if(zimm!=0) CSR[csr] = xrd | (unsigned<XLEN>)zimm;
+                if(rd!=0) X[rd] = xrd;
             }
         }
         CSRRCI {
             encoding: csr[11:0] :: zimm[4:0] :: 0b111 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
-	            unsigned<XLEN> xrd = CSR[csr];
-                if(zimm!=0) CSR[csr] = xrd & ~((unsigned<XLEN>)zimm);    
-	            if(rd!=0) X[rd] = xrd;
+                unsigned<XLEN> xrd = CSR[csr];
+                if(zimm!=0) CSR[csr] = xrd & ~((unsigned<XLEN>)zimm);
+                if(rd!=0) X[rd] = xrd;
             }
-        }   
+        }
     }
 }
 
@@ -342,11 +341,9 @@ InstructionSet Zifencei extends RISCVBase {
             args_disass:"{name(rs2)}, {rs1}";
             behavior: {
                 FENCE[fencevmal] = (unsigned)rs1;
-            FENCE[fencevmau] = (unsigned)rs2;
+                FENCE[fencevmau] = (unsigned)rs2;
             }
         }
-     }
-     
- }
-     
+    }
+}
 

--- a/RV64I.core_desc
+++ b/RV64I.core_desc
@@ -6,24 +6,24 @@ InstructionSet RV64I extends RV32I {
             encoding: imm[11:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0000011;
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-	            unsigned offs = X[rs1]+(signed<12>)imm;
-	            if(rd!=0) X[rd]=(unsigned<32>)MEM[offs];
+                unsigned offs = X[rs1]+(signed<12>)imm;
+                if(rd!=0) X[rd]=(unsigned<32>)MEM[offs];
             }
         }
         LD{
             encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0000011;
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-	            unsigned offs = X[rs1] + (signed<12>)imm;
-	            if(rd!=0) X[rd]=(unsigned<64>)MEM[offs];
+                unsigned offs = X[rs1] + (signed<12>)imm;
+                if(rd!=0) X[rd]=(unsigned<64>)MEM[offs];
             }
         }
         SD{
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: imm[4:0] :: 0b0100011;
             args_disass:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
-            	unsigned offs = X[rs1] + (signed<12>)imm;
-            	MEM[offs] = X[rs2];
+                unsigned offs = X[rs1] + (signed<12>)imm;
+                MEM[offs] = X[rs2];
             }
         }
         SLLI {
@@ -45,93 +45,92 @@ InstructionSet RV64I extends RV32I {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0011011;
             args_disass:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: {
-	            if(rd != 0){
-	                unsigned<32> res = X[rs1] + (signed<12>)imm;
-	                X[rd] = res;
-	            } 
+                if(rd != 0){
+                    unsigned<32> res = X[rs1] + (signed<12>)imm;
+                    X[rd] = res;
+                }
             }
         }
         SLLIW {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0011011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
-	            if(rd != 0){
-	                unsigned<32> sh_val = ((unsigned<32>)X[rs1])<< shamt;
-	                X[rd] = (signed<64>)sh_val;
-	            } 
+                if(rd != 0){
+                    unsigned<32> sh_val = ((unsigned<32>)X[rs1])<< shamt;
+                    X[rd] = (signed<64>)sh_val;
+                }
             }
         }
         SRLIW {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0011011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
-	            if(rd != 0){
-	                unsigned<32> sh_val =((unsigned<32>)X[rs1])>> shamt;
-	                X[rd] = (signed<64>)sh_val;
-	            }           
+                if(rd != 0){
+                    unsigned<32> sh_val =((unsigned<32>)X[rs1])>> shamt;
+                    X[rd] = (signed<64>)sh_val;
+                }
             }
         }
         SRAIW {
             encoding: 0b0100000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0011011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
-	            if(rd != 0){
-	                signed<32> sh_val = ((signed<32>)X[rs1])>> shamt;    
-	                X[rd] = (signed<64>)sh_val;
-	            }
+                if(rd != 0){
+                    signed<32> sh_val = ((signed<32>)X[rs1])>> shamt;
+                    X[rd] = (signed<64>)sh_val;
+                }
             }
         }
         ADDW {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
             behavior: {
-	            if(rd != 0){
-	                signed<32> res = (signed<32>)X[rs1] + (signed<32>)X[rs2];
-	                X[rd] = (signed<64>)res;
-	            } 
+                if(rd != 0){
+                    signed<32> res = (signed<32>)X[rs1] + (signed<32>)X[rs2];
+                    X[rd] = (signed<64>)res;
+                }
             }
         }
         SUBW {
             encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
             behavior: {
-            	if(rd != 0){
-	                signed<32> res = (signed<32>)X[rs1] - (signed<32>)X[rs2];
-	                X[rd] = (signed<64>)res;
-	            } 
+                if(rd != 0){
+                    signed<32> res = (signed<32>)X[rs1] - (signed<32>)X[rs2];
+                    X[rd] = (signed<64>)res;
+                }
             }
         }
         SLLW {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                unsigned count = (unsigned)X[rs2] & 0x1f;
-	                unsigned<32> sh_val =((unsigned<32>)X[rs1]) << count;
-	                X[rd] = (unsigned<64>)sh_val;
-	            } 
+                if(rd != 0){
+                    unsigned count = (unsigned)X[rs2] & 0x1f;
+                    unsigned<32> sh_val =((unsigned<32>)X[rs1]) << count;
+                    X[rd] = (unsigned<64>)sh_val;
+                }
             }
         }
         SRLW {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-    	        if(rd != 0){
-	                unsigned count = (unsigned)X[rs2] & 0x1f;
-	                unsigned<32> sh_val =((unsigned<32>)X[rs1]) >> count;
-	                X[rd] = (unsigned<64>)sh_val;
-	            } 
+                if(rd != 0){
+                    unsigned count = (unsigned)X[rs2] & 0x1f;
+                    unsigned<32> sh_val =((unsigned<32>)X[rs1]) >> count;
+                    X[rd] = (unsigned<64>)sh_val;
+                }
             }
         }
         SRAW {
             encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                unsigned count = (unsigned)X[rs2] & 0x1f;
-	                signed<32> sh_val =((signed<32>)X[rs1]) >> count;
-	                X[rd] = (signed<64>)sh_val;
-    	        } 
+                if(rd != 0){
+                    unsigned count = (unsigned)X[rs2] & 0x1f;
+                    signed<32> sh_val =((signed<32>)X[rs1]) >> count;
+                    X[rd] = (signed<64>)sh_val;
+                }
             }
         }
-    }    
+    }
 }
-

--- a/RV64I.core_desc
+++ b/RV64I.core_desc
@@ -3,47 +3,47 @@ import "RV32I.core_desc"
 InstructionSet RV64I extends RV32I {
     instructions{
         LWU { //    80000104: 0000ef03            lwu t5,0(ra)
-            encoding: imm[11:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0000011;
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned offs = X[rs1]+(signed<12>)imm;
                 if(rd!=0) X[rd]=(unsigned<32>)MEM[offs];
             }
         }
         LD{
-            encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0000011;
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned offs = X[rs1] + (signed<12>)imm;
                 if(rd!=0) X[rd]=(unsigned<64>)MEM[offs];
             }
         }
         SD{
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: imm[4:0] :: 0b0100011;
-            args_disass:"{name(rs2)}, {imm}({name(rs1)})";
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: imm[4:0] :: 7'b0100011;
+            assembly: "{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned offs = X[rs1] + (signed<12>)imm;
                 MEM[offs] = X[rs2];
             }
         }
         SLLI {
-            encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd != 0) X[rd] = X[rs1] << shamt;
         }
         SRLI {
-            encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd != 0) X[rd] = ((unsigned<64>)X[rs1])>>shamt;
         }
         SRAI {
-            encoding: 0b010000 :: shamt[5:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            encoding: 0b010000 :: shamt[5:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd != 0) X[rd] = ((signed<64>)X[rs1])>>shamt;
         }
         ADDIW {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0011011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0011011;
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: {
                 if(rd != 0){
                     unsigned<32> res = X[rs1] + (signed<12>)imm;
@@ -52,8 +52,8 @@ InstructionSet RV64I extends RV32I {
             }
         }
         SLLIW {
-            encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0011011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0011011;
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
                 if(rd != 0){
                     unsigned<32> sh_val = ((unsigned<32>)X[rs1])<< shamt;
@@ -62,8 +62,8 @@ InstructionSet RV64I extends RV32I {
             }
         }
         SRLIW {
-            encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0011011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0011011;
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
                 if(rd != 0){
                     unsigned<32> sh_val =((unsigned<32>)X[rs1])>> shamt;
@@ -72,8 +72,8 @@ InstructionSet RV64I extends RV32I {
             }
         }
         SRAIW {
-            encoding: 0b0100000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0011011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            encoding: 7'b0100000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0011011;
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
                 if(rd != 0){
                     signed<32> sh_val = ((signed<32>)X[rs1])>> shamt;
@@ -82,7 +82,7 @@ InstructionSet RV64I extends RV32I {
             }
         }
         ADDW {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0111011;
             behavior: {
                 if(rd != 0){
                     signed<32> res = (signed<32>)X[rs1] + (signed<32>)X[rs2];
@@ -91,7 +91,7 @@ InstructionSet RV64I extends RV32I {
             }
         }
         SUBW {
-            encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0111011;
             behavior: {
                 if(rd != 0){
                     signed<32> res = (signed<32>)X[rs1] - (signed<32>)X[rs2];
@@ -100,8 +100,8 @@ InstructionSet RV64I extends RV32I {
             }
         }
         SLLW {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0111011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     unsigned count = (unsigned)X[rs2] & 0x1f;
@@ -111,8 +111,8 @@ InstructionSet RV64I extends RV32I {
             }
         }
         SRLW {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     unsigned count = (unsigned)X[rs2] & 0x1f;
@@ -122,8 +122,8 @@ InstructionSet RV64I extends RV32I {
             }
         }
         SRAW {
-            encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     unsigned count = (unsigned)X[rs2] & 0x1f;

--- a/RV64I.core_desc
+++ b/RV64I.core_desc
@@ -6,7 +6,7 @@ InstructionSet RV64I extends RV32I {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0000011;
             assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned offs = X[rs1]+(signed<12>)imm;
+                unsigned<XLEN> offs = X[rs1]+(signed<12>)imm;
                 if(rd!=0) X[rd]=(unsigned<32>)MEM[offs];
             }
         }
@@ -14,7 +14,7 @@ InstructionSet RV64I extends RV32I {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0000011;
             assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned offs = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 if(rd!=0) X[rd]=(unsigned<64>)MEM[offs];
             }
         }
@@ -22,7 +22,7 @@ InstructionSet RV64I extends RV32I {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: imm[4:0] :: 7'b0100011;
             assembly: "{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned offs = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 MEM[offs] = X[rs2];
             }
         }
@@ -104,7 +104,7 @@ InstructionSet RV64I extends RV32I {
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
-                    unsigned count = (unsigned)X[rs2] & 0x1f;
+                    unsigned<5> count = X[rs2][4:0];
                     unsigned<32> sh_val =((unsigned<32>)X[rs1]) << count;
                     X[rd] = (unsigned<64>)sh_val;
                 }
@@ -115,7 +115,7 @@ InstructionSet RV64I extends RV32I {
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
-                    unsigned count = (unsigned)X[rs2] & 0x1f;
+                    unsigned<5> count = X[rs2][4:0];
                     unsigned<32> sh_val =((unsigned<32>)X[rs1]) >> count;
                     X[rd] = (unsigned<64>)sh_val;
                 }
@@ -126,7 +126,7 @@ InstructionSet RV64I extends RV32I {
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
-                    unsigned count = (unsigned)X[rs2] & 0x1f;
+                    unsigned<5> count = X[rs2][4:0];
                     signed<32> sh_val =((signed<32>)X[rs1]) >> count;
                     X[rd] = (signed<64>)sh_val;
                 }

--- a/RVA.core_desc
+++ b/RVA.core_desc
@@ -3,8 +3,8 @@ import "RISCVBase.core_desc"
 InstructionSet RV32A extends RISCVBase {
     instructions{
         LRW {
-            encoding: 0b00010 :: aq[0:0] :: rl[0:0]  :: 0b00000 :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(aq)}, {name(rl)}";
+            encoding: 5'b00010 :: aq[0:0] :: rl[0:0]  :: 5'b00000 :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(aq)}, {name(rl)}";
             behavior: if(rd!=0){
                 unsigned<XLEN> offs = X[rs1];
                 X[rd] = (int<32>)MEM[offs];
@@ -12,8 +12,8 @@ InstructionSet RV32A extends RISCVBase {
             }
         }
         SCW {
-            encoding: 0b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)}, {name(aq)}, {name(rl)}";
+            encoding: 5'b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}, {name(aq)}, {name(rl)}";
             behavior:  {
                 unsigned<XLEN> offs = X[rs1];
                 unsigned<32>  res1 = RES[offs];
@@ -24,8 +24,8 @@ InstructionSet RV32A extends RISCVBase {
             }
         }
         AMOSWAPW{
-            encoding: 0b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN> offs=X[rs1];
                 if(rd!=0) X[rd]=(signed<32>)MEM[offs];
@@ -33,8 +33,8 @@ InstructionSet RV32A extends RISCVBase {
             }
         }
         AMOADDW{
-            encoding: 0b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs=X[rs1];
                 signed<XLEN>  res1 = MEM[offs];
@@ -44,8 +44,8 @@ InstructionSet RV32A extends RISCVBase {
             }
         }
         AMOXORW{
-            encoding: 0b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN> offs = X[rs1];
                 signed<XLEN> res1 = MEM[offs];
@@ -55,8 +55,8 @@ InstructionSet RV32A extends RISCVBase {
             }
         }
         AMOANDW{
-            encoding: 0b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN> offs=X[rs1];
                 signed<XLEN>  res1 = MEM[offs];
@@ -66,8 +66,8 @@ InstructionSet RV32A extends RISCVBase {
             }
         }
         AMOORW {
-            encoding: 0b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs=X[rs1];
                 signed<XLEN>  res1 = MEM[offs];
@@ -77,8 +77,8 @@ InstructionSet RV32A extends RISCVBase {
             }
         }
         AMOMINW{
-            encoding: 0b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs=X[rs1];
                 signed<XLEN>  res1 = MEM[offs];
@@ -88,8 +88,8 @@ InstructionSet RV32A extends RISCVBase {
             }
         }
         AMOMAXW{
-            encoding: 0b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs=X[rs1];
                 signed<XLEN>  res1 = MEM[offs];
@@ -99,8 +99,8 @@ InstructionSet RV32A extends RISCVBase {
             }
         }
         AMOMINUW{
-            encoding: 0b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs=X[rs1];
                 signed<XLEN>  res1 = MEM[offs];
@@ -110,8 +110,8 @@ InstructionSet RV32A extends RISCVBase {
             }
         }
         AMOMAXUW{
-            encoding: 0b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs=X[rs1];
                 signed<XLEN>  res1 = MEM[offs];
@@ -126,8 +126,8 @@ InstructionSet RV32A extends RISCVBase {
 InstructionSet RV64A extends RV32A {
     instructions{
         LRD {
-            encoding: 0b00010 :: aq[0:0] :: rl[0:0]  :: 0b00000 :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}";
+            encoding: 5'b00010 :: aq[0:0] :: rl[0:0]  :: 5'b00000 :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}";
             behavior:  {
                 if(rd!=0){
                     unsigned<XLEN>  offs = X[rs1];
@@ -137,8 +137,8 @@ InstructionSet RV64A extends RV32A {
             }
         }
         SCD {
-            encoding: 0b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 5'b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior:  {
             unsigned<XLEN>  offs = X[rs1];
             unsigned<XLEN>  res[64] = RES[offs];
@@ -151,8 +151,8 @@ InstructionSet RV64A extends RV32A {
             }
         }
         AMOSWAPD{
-            encoding: 0b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs = X[rs1];
                 if(rd!=0) X[rd] = MEM[offs];
@@ -160,8 +160,8 @@ InstructionSet RV64A extends RV32A {
             }
         }
         AMOADDD{
-            encoding: 0b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs = X[rs1];
                 signed<XLEN>  res = MEM[offs];
@@ -171,8 +171,8 @@ InstructionSet RV64A extends RV32A {
             }
         }
         AMOXORD{
-            encoding: 0b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs = X[rs1];
                 signed<XLEN>  res = MEM[offs];
@@ -182,8 +182,8 @@ InstructionSet RV64A extends RV32A {
             }
         }
         AMOANDD{
-            encoding: 0b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs = X[rs1];
                 signed<XLEN>  res = MEM[offs];
@@ -193,8 +193,8 @@ InstructionSet RV64A extends RV32A {
             }
         }
         AMOORD {
-            encoding: 0b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs = X[rs1];
                 signed<XLEN>  res = MEM[offs];
@@ -204,8 +204,8 @@ InstructionSet RV64A extends RV32A {
             }
         }
         AMOMIND{
-            encoding: 0b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs = X[rs1];
                 signed<XLEN>  res1 = MEM[offs];
@@ -215,8 +215,8 @@ InstructionSet RV64A extends RV32A {
             }
         }
         AMOMAXD{
-            encoding: 0b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs = X[rs1];
                 signed<XLEN>  res = MEM[offs];
@@ -226,8 +226,8 @@ InstructionSet RV64A extends RV32A {
             }
         }
         AMOMINUD{
-            encoding: 0b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs = X[rs1];
                 unsigned<XLEN>  res = MEM[offs];
@@ -237,8 +237,8 @@ InstructionSet RV64A extends RV32A {
             }
         }
         AMOMAXUD{
-            encoding: 0b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
+            encoding: 5'b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
                 unsigned<XLEN>  offs = X[rs1];
                 unsigned<XLEN> res1 = MEM[offs];

--- a/RVA.core_desc
+++ b/RVA.core_desc
@@ -7,7 +7,7 @@ InstructionSet RV32A extends RISCVBase {
             assembly: "{name(rd)}, {name(rs1)}, {name(aq)}, {name(rl)}";
             behavior: if(rd!=0){
                 unsigned<XLEN> offs = X[rs1];
-                X[rd] = (int<32>)MEM[offs];
+                X[rd] = (signed<32>)MEM[offs];
                 RES[offs]=-1;
             }
         }

--- a/RVA.core_desc
+++ b/RVA.core_desc
@@ -1,7 +1,6 @@
 import "RISCVBase.core_desc"
 
 InstructionSet RV32A extends RISCVBase {
-     
     instructions{
         LRW {
             encoding: 0b00010 :: aq[0:0] :: rl[0:0]  :: 0b00000 :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
@@ -16,126 +15,125 @@ InstructionSet RV32A extends RISCVBase {
             encoding: 0b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)}, {name(aq)}, {name(rl)}";
             behavior:  {
-				unsigned<XLEN> offs = X[rs1];
-            	unsigned<32>  res1 = RES[offs];
-            	if(res1!=0)
-                	MEM[offs] = X[rs2];
-            	if(rd!=0)
-            		X[rd] = res1? 0: 1;
+                unsigned<XLEN> offs = X[rs1];
+                unsigned<32>  res1 = RES[offs];
+                if(res1!=0)
+                    MEM[offs] = X[rs2];
+                if(rd!=0)
+                    X[rd] = res1? 0: 1;
             }
         }
         AMOSWAPW{
             encoding: 0b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN> offs=X[rs1];
-	            if(rd!=0) X[rd]=(signed<32>)MEM[offs];
-	            MEM[offs]=X[rs2];
+                unsigned<XLEN> offs=X[rs1];
+                if(rd!=0) X[rd]=(signed<32>)MEM[offs];
+                MEM[offs]=X[rs2];
             }
         }
         AMOADDW{
             encoding: 0b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2 =res1 + X[rs2];
-	            MEM[offs]=res2;
+                unsigned<XLEN>  offs=X[rs1];
+                signed<XLEN>  res1 = MEM[offs];
+                if(rd!=0) X[rd]=res1;
+                unsigned<XLEN>  res2 =res1 + X[rs2];
+                MEM[offs]=res2;
             }
         }
         AMOXORW{
             encoding: 0b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN> offs = X[rs1];
-	            signed<XLEN> res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2 =res1 ^ X[rs2];
-	            MEM[offs]=res2;
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res1 = MEM[offs];
+                if(rd!=0) X[rd]=res1;
+                unsigned<XLEN>  res2 =res1 ^ X[rs2];
+                MEM[offs]=res2;
             }
         }
         AMOANDW{
             encoding: 0b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN> offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2 =res1 & X[rs2];
-	            MEM[offs]=res2;
+                unsigned<XLEN> offs=X[rs1];
+                signed<XLEN>  res1 = MEM[offs];
+                if(rd!=0) X[rd]=res1;
+                unsigned<XLEN>  res2 =res1 & X[rs2];
+                MEM[offs]=res2;
             }
         }
         AMOORW {
             encoding: 0b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2=res1 :: X[rs2];
-	            MEM[offs]=res2;
+                unsigned<XLEN>  offs=X[rs1];
+                signed<XLEN>  res1 = MEM[offs];
+                if(rd!=0) X[rd]=res1;
+                unsigned<XLEN>  res2=res1 :: X[rs2];
+                MEM[offs]=res2;
             }
         }
         AMOMINW{
             encoding: 0b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd] = res1;
-	            unsigned<XLEN>  res2 = (signed<XLEN>)res1 > (signed<XLEN>)X[rs2]? X[rs2]: res1;
-	            MEM[offs] = res2;
+                unsigned<XLEN>  offs=X[rs1];
+                signed<XLEN>  res1 = MEM[offs];
+                if(rd!=0) X[rd] = res1;
+                unsigned<XLEN>  res2 = (signed<XLEN>)res1 > (signed<XLEN>)X[rs2]? X[rs2]: res1;
+                MEM[offs] = res2;
             }
         }
         AMOMAXW{
             encoding: 0b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2= res1<(signed<XLEN>) X[rs2]? X[rs2] : res1;
-	            MEM[offs]=res2;
+                unsigned<XLEN>  offs=X[rs1];
+                signed<XLEN>  res1 = MEM[offs];
+                if(rd!=0) X[rd]=res1;
+                unsigned<XLEN>  res2= res1<(signed<XLEN>) X[rs2]? X[rs2] : res1;
+                MEM[offs]=res2;
             }
         }
         AMOMINUW{
             encoding: 0b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2= res1>(signed<XLEN>)X[rs2]? X[rs2] : res1;
-	            MEM[offs]=res2;
+                unsigned<XLEN>  offs=X[rs1];
+                signed<XLEN>  res1 = MEM[offs];
+                if(rd!=0) X[rd]=res1;
+                unsigned<XLEN>  res2= res1>(signed<XLEN>)X[rs2]? X[rs2] : res1;
+                MEM[offs]=res2;
             }
         }
         AMOMAXUW{
             encoding: 0b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd] = res1;
-	            unsigned<XLEN>  res2 = res1 < X[rs2]? X[rs2] : res1;
-	            MEM[offs] = res2;
+                unsigned<XLEN>  offs=X[rs1];
+                signed<XLEN>  res1 = MEM[offs];
+                if(rd!=0) X[rd] = res1;
+                unsigned<XLEN>  res2 = res1 < X[rs2]? X[rs2] : res1;
+                MEM[offs] = res2;
             }
         }
     }
 }
 
 InstructionSet RV64A extends RV32A {
-     
     instructions{
         LRD {
             encoding: 0b00010 :: aq[0:0] :: rl[0:0]  :: 0b00000 :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}";
             behavior:  {
-	            if(rd!=0){
-	                unsigned<XLEN>  offs = X[rs1];
-	                X[rd]= (signed<XLEN> )MEM[offs];
-	                RES[offs]=-1;
-	            }
+                if(rd!=0){
+                    unsigned<XLEN>  offs = X[rs1];
+                    X[rd]= (signed<XLEN> )MEM[offs];
+                    RES[offs]=-1;
+                }
             }
         }
         SCD {
@@ -144,109 +142,109 @@ InstructionSet RV64A extends RV32A {
             behavior:  {
             unsigned<XLEN>  offs = X[rs1];
             unsigned<XLEN>  res[64] = RES[offs];
-	            if(res!=0){
-	                MEM[offs] = X[rs2];
-	                if(rd!=0) X[rd]=0;
-	            } else{ 
-	                if(rd!=0) X[rd]= 1;
-	            }
+                if(res!=0){
+                    MEM[offs] = X[rs2];
+                    if(rd!=0) X[rd]=0;
+                } else{
+                    if(rd!=0) X[rd]= 1;
+                }
             }
         }
         AMOSWAPD{
             encoding: 0b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            if(rd!=0) X[rd] = MEM[offs];
-	            MEM[offs] = X[rs2];            
+                unsigned<XLEN>  offs = X[rs1];
+                if(rd!=0) X[rd] = MEM[offs];
+                MEM[offs] = X[rs2];
             }
         }
         AMOADDD{
             encoding: 0b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd]=res;
-	            unsigned<XLEN>  res2 = res + X[rs2];
-	            MEM[offs]=res2;            
+                unsigned<XLEN>  offs = X[rs1];
+                signed<XLEN>  res = MEM[offs];
+                if(rd!=0) X[rd]=res;
+                unsigned<XLEN>  res2 = res + X[rs2];
+                MEM[offs]=res2;
             }
         }
         AMOXORD{
             encoding: 0b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd] = res;
-	            unsigned<XLEN>  res2 = res ^ X[rs2];
-	            MEM[offs] = res2;            
+                unsigned<XLEN>  offs = X[rs1];
+                signed<XLEN>  res = MEM[offs];
+                if(rd!=0) X[rd] = res;
+                unsigned<XLEN>  res2 = res ^ X[rs2];
+                MEM[offs] = res2;
             }
         }
         AMOANDD{
             encoding: 0b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd] = res;
-	            unsigned<XLEN>  res2 = res & X[rs2];
-	            MEM[offs] = res2;            
+                unsigned<XLEN>  offs = X[rs1];
+                signed<XLEN>  res = MEM[offs];
+                if(rd!=0) X[rd] = res;
+                unsigned<XLEN>  res2 = res & X[rs2];
+                MEM[offs] = res2;
             }
         }
         AMOORD {
             encoding: 0b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd] = res;
-	            unsigned<XLEN>  res2 = res :: X[rs2];
-	            MEM[offs] = res2;            
+                unsigned<XLEN>  offs = X[rs1];
+                signed<XLEN>  res = MEM[offs];
+                if(rd!=0) X[rd] = res;
+                unsigned<XLEN>  res2 = res :: X[rs2];
+                MEM[offs] = res2;
             }
         }
         AMOMIND{
             encoding: 0b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd] = res1;
-	            unsigned<XLEN>  res2 = res1 > (signed<XLEN> )X[rs2]? X[rs2] : res1;
-	            MEM[offs] = res2;
+                unsigned<XLEN>  offs = X[rs1];
+                signed<XLEN>  res1 = MEM[offs];
+                if(rd!=0) X[rd] = res1;
+                unsigned<XLEN>  res2 = res1 > (signed<XLEN> )X[rs2]? X[rs2] : res1;
+                MEM[offs] = res2;
             }
         }
         AMOMAXD{
             encoding: 0b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd] = res;
-	            unsigned<XLEN>  res2 = res < (signed<XLEN>)X[rs2]? X[rs2] : res;            
-	            MEM[offs] = res2;            
+                unsigned<XLEN>  offs = X[rs1];
+                signed<XLEN>  res = MEM[offs];
+                if(rd!=0) X[rd] = res;
+                unsigned<XLEN>  res2 = res < (signed<XLEN>)X[rs2]? X[rs2] : res;
+                MEM[offs] = res2;
             }
         }
         AMOMINUD{
             encoding: 0b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            unsigned<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd] = res;
-	            unsigned<XLEN>  res2 = res > X[rs2]? X[rs2] : res;            
-	            MEM[offs] = res2;            
+                unsigned<XLEN>  offs = X[rs1];
+                unsigned<XLEN>  res = MEM[offs];
+                if(rd!=0) X[rd] = res;
+                unsigned<XLEN>  res2 = res > X[rs2]? X[rs2] : res;
+                MEM[offs] = res2;
             }
         }
         AMOMAXUD{
             encoding: 0b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
             behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            unsigned<XLEN> res1 = MEM[offs];
-	            if(rd!=0) X[rd] = res1;
-	            unsigned<XLEN>  res2 = res1 < X[rs2]? X[rs2] : res1;
-	            MEM[offs] = res2;
+                unsigned<XLEN>  offs = X[rs1];
+                unsigned<XLEN> res1 = MEM[offs];
+                if(rd!=0) X[rd] = res1;
+                unsigned<XLEN>  res2 = res1 < X[rs2]? X[rs2] : res1;
+                MEM[offs] = res2;
             }
         }
     }

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -6,7 +6,7 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1100111;
             assembly: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
-                int<XLEN> new_pc = X[rs1] + (signed<12>)imm;
+                signed<XLEN> new_pc = X[rs1] + (signed<12>)imm;
                 if(rd!=0) X[rd] = PC+4;
                 PC=new_pc & ~0x1;
             }
@@ -87,7 +87,7 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 3'b100 :: 1'b0 :: 2'b00 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
             assembly: "{name(8+rs1)}, {shamt}";
             behavior: {
-                unsigned rs1_idx = rs1+8;
+                unsigned<5> rs1_idx = rs1+8;
                 X[rs1_idx] = X[rs1_idx] >> shamt;
             }
         }
@@ -95,10 +95,10 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 3'b100 :: 1'b0 :: 2'b01 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
             assembly: "{name(8+rs1)}, {shamt}";
             behavior: if(shamt){
-                unsigned rs1_idx = rs1+8;
+                unsigned<5> rs1_idx = rs1+8;
                 X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> shamt;
             } else if(XLEN==128){
-                unsigned rs1_idx = rs1+8;
+                unsigned<5> rs1_idx = rs1+8;
                 X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> 64;
             }
         }
@@ -106,7 +106,7 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 3'b100 :: imm[5:5] :: 2'b10 :: rs1[2:0] :: imm[4:0] :: 2'b01;
             assembly: "{name(8+rs1)}, {imm:#05x}";
             behavior: {
-                unsigned rs1_idx = rs1 + 8;
+                unsigned<5> rs1_idx = rs1 + 8;
                 X[rs1_idx] = X[rs1_idx] & (signed<6>)imm;
             }
         }
@@ -114,7 +114,7 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b00 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-                unsigned rd_idx = rd + 8;
+                unsigned<5> rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] - X[rs2 + 8];
             }
         }
@@ -122,7 +122,7 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b01 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-                unsigned rd_idx = rd + 8;
+                unsigned<5> rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] ^ X[rs2 + 8];
             }
         }
@@ -130,7 +130,7 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b10 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-                unsigned rd_idx = rd + 8;
+                unsigned<5> rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] | X[rs2 + 8];
             }
         }
@@ -138,7 +138,7 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b11 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-                unsigned rd_idx = rd + 8;
+                unsigned<5> rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] & X[rs2 + 8];
             }
         }
@@ -222,6 +222,11 @@ InstructionSet RV32IC extends RISCVBase{
         }
     }
 }
+
+//===---------------------------------------------------------------------===//
+// Definitions below are not yet valid CoreDSL 2 syntax
+//===---------------------------------------------------------------------===//
+
 /*
 InstructionSet RV32FC extends RISCVBase{
     constants {

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -1,13 +1,12 @@
 import "RISCVBase.core_desc"
 
 InstructionSet RV32IC extends RISCVBase{
-
     instructions{
          JALR[[no_cont]]{ // overwriting the implementation if rv32i, alignment does not need to be word
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1100111;
             args_disass: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
-	            int<XLEN> new_pc = X[rs1] + (signed<12>)imm;
+                int<XLEN> new_pc = X[rs1] + (signed<12>)imm;
                 if(rd!=0) X[rd] = PC+4;
                 PC=new_pc & ~0x1;
             }
@@ -16,15 +15,15 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 0b000 :: imm[5:4] :: imm[9:6] :: imm[2:2] :: imm[3:3] :: rd[2:0] :: 0b00;
             args_disass: "{name(rd)}, {imm:#05x}";
             behavior:
-            	if(imm) X[rd+8] = X[2] + imm;
-            	else raise(0, 2);
+                if(imm) X[rd+8] = X[2] + imm;
+                else raise(0, 2);
         }
         CLW { // (RV32)
             encoding: 0b010 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 0b00;
             args_disass: "{name(8+rd)}, {uimm:#05x}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1+8] + uimm;
-	            X[rd+8] = (signed<32>)MEM[load_address];
+                X[rd+8] = (signed<32>)MEM[load_address];
             }
         }
         CSW {//(RV32)
@@ -51,16 +50,16 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 0b001 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 0b01;
             args_disass: "{imm:#05x}";
             behavior: {
-	            X[1] = PC+2;
-	            PC=PC+(signed<12>)imm;
+                X[1] = PC+2;
+                PC=PC+(signed<12>)imm;
             }
         }
         CLI {//(RV32)
             encoding: 0b010 :: imm[5:5] :: rd[4:0] :: imm[4:0] :: 0b01;
             args_disass: "{name(rd)}, {imm:#05x}";
             behavior: {
-	            if(rd != 0)   //rd==0 is a hint, so no trap
-	               X[rd] = (unsigned<XLEN>)(signed)imm;
+                if(rd != 0)   //rd==0 is a hint, so no trap
+                   X[rd] = (unsigned<XLEN>)(signed)imm;
             }
         }
         // order matters here as CADDI16SP overwrites CLUI for rd==2
@@ -69,14 +68,14 @@ InstructionSet RV32IC extends RISCVBase{
             args_disass: "{name(rd)}, {imm:#05x}";
             behavior: {
                 if(imm == 0) raise(0, 2);
-                if(rd != 0) 
+                if(rd != 0)
                     X[rd] = (signed<18>)imm;
             }
         }
         CADDI16SP {//(RV32)
             encoding: 0b011 :: nzimm[9:9] :: 0b00010 :: nzimm[4:4] :: nzimm[6:6] :: nzimm[8:7] :: nzimm[5:5] :: 0b01;
             args_disass: "{nzimm:#05x}";
-            behavior:  
+            behavior:
                 if(nzimm) X[2] = X[2] + (signed<10>)nzimm;
                 else raise(0, 2);
         }
@@ -88,59 +87,59 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 0b100 :: 0b0 :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
             behavior: {
-	            unsigned rs1_idx = rs1+8;
-	            X[rs1_idx] = X[rs1_idx] >> shamt;
+                unsigned rs1_idx = rs1+8;
+                X[rs1_idx] = X[rs1_idx] >> shamt;
             }
         }
         CSRAI {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
             behavior: if(shamt){
-	            unsigned rs1_idx = rs1+8;
-	            X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> shamt;
+                unsigned rs1_idx = rs1+8;
+                X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> shamt;
             } else if(XLEN==128){
                 unsigned rs1_idx = rs1+8;
-                X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> 64;               
-            } 
+                X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> 64;
+            }
         }
         CANDI {//(RV32)
             encoding: 0b100 :: imm[5:5] :: 0b10 :: rs1[2:0] :: imm[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {imm:#05x}";
             behavior: {
-	            unsigned rs1_idx = rs1 + 8;
-	            X[rs1_idx] = X[rs1_idx] & (signed<6>)imm;
+                unsigned rs1_idx = rs1 + 8;
+                X[rs1_idx] = X[rs1_idx] & (signed<6>)imm;
             }
         }
         CSUB {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b00 :: rs2[2:0] :: 0b01;
             args_disass: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-            	unsigned rd_idx = rd + 8;
-            	X[rd_idx] = X[rd_idx] - X[rs2 + 8];
+                unsigned rd_idx = rd + 8;
+                X[rd_idx] = X[rd_idx] - X[rs2 + 8];
             }
         }
         CXOR {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b01 :: rs2[2:0] :: 0b01;
             args_disass: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-            	unsigned rd_idx = rd + 8;
-            	X[rd_idx] = X[rd_idx] ^ X[rs2 + 8];
+                unsigned rd_idx = rd + 8;
+                X[rd_idx] = X[rd_idx] ^ X[rs2 + 8];
             }
         }
         COR {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b10 :: rs2[2:0] :: 0b01;
             args_disass: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-	            unsigned rd_idx = rd + 8;
-            	X[rd_idx] = X[rd_idx] | X[rs2 + 8];
+                unsigned rd_idx = rd + 8;
+                X[rd_idx] = X[rd_idx] | X[rs2 + 8];
             }
         }
         CAND {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b11 :: rs2[2:0] :: 0b01;
             args_disass: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-            	unsigned rd_idx = rd + 8;
-            	X[rd_idx] = X[rd_idx] & X[rs2 + 8];
+                unsigned rd_idx = rd + 8;
+                X[rd_idx] = X[rd_idx] & X[rs2 + 8];
             }
         }
         CJ[[no_cont]] {//(RV32)
@@ -167,9 +166,9 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 0b010 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 0b10;
             args_disass: "{name(rd)}, sp, {uimm:#05x}";
             behavior: if(rd){
-    	        unsigned<XLEN> offs = X[2] + uimm;
+                unsigned<XLEN> offs = X[2] + uimm;
                 X[rd] = (signed<32>)MEM[offs];
-            } else 
+            } else
                 raise(0,2);
         }
         // order matters as CJR is a special case of CMV
@@ -213,8 +212,8 @@ InstructionSet RV32IC extends RISCVBase{
             encoding: 0b110 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 0b10;
             args_disass: "{name(rs2)}, {uimm:#05x}(sp)";
             behavior: {
-	            unsigned<XLEN> offs = X[2] + uimm;
-	            MEM[offs] = (unsigned<32>)X[rs2];
+                unsigned<XLEN> offs = X[2] + uimm;
+                MEM[offs] = (unsigned<32>)X[rs2];
             }
         }
         DII[[no_cont]] { // Defined Illegal Instruction
@@ -228,7 +227,7 @@ InstructionSet RV32FC extends RISCVBase{
     constants {
         FLEN
     }
-    registers { 
+    registers {
         [31:0]   F[FLEN]
     }
     instructions{
@@ -243,7 +242,7 @@ InstructionSet RV32FC extends RISCVBase{
                 val upper[FLEN] <= -1;
                 F[rd+8] <= (upper<<32) :: zext(res, FLEN);
             }
-        } 
+        }
         CFSW {
             encoding: 0b111 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 0b00;
             args_disass:"f(8+{rs2}), {uimm}({name(8+rs1)})";
@@ -267,7 +266,7 @@ InstructionSet RV32FC extends RISCVBase{
             args_disass:"f{rs2}, {uimm}(x2), ";
             val offs[XLEN] <= X[2]+uimm;
             MEM[offs]{32}<=F[rs2]{32};
-        }        
+        }
     }
 }
 
@@ -275,7 +274,7 @@ InstructionSet RV32DC extends RISCVBase{
     constants {
         FLEN
     }
-    registers { 
+    registers {
         [31:0]   F[FLEN]
     }
     instructions{
@@ -296,7 +295,7 @@ InstructionSet RV32DC extends RISCVBase{
             args_disass:"f(8+{rs2}), {uimm}({name(8+rs1)})";
             val offs[XLEN] <= X[rs1+8]+uimm;
             MEM[offs]{64}<=F[rs2+8]{64};
-        } 
+        }
         CFLDSP {//(RV32/64)
             encoding:b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
             args_disass:"f{rd}, {uimm}(x2)";
@@ -319,15 +318,14 @@ InstructionSet RV32DC extends RISCVBase{
 }
 
 InstructionSet RV64IC extends RV32IC {
-
     instructions{
-        CLD {//(RV64/128) 
+        CLD {//(RV64/128)
             encoding:b011 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
             args_disass: "{name(8+rd)}, {uimm},({name(8+rs1)})";
             val offs[XLEN] <= X[rs1+8] + uimm;
             X[rd+8]<=sext(MEM[offs]{64});
         }
-        CSD { //(RV64/128) 
+        CSD { //(RV64/128)
             encoding:b111 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
             args_disass: "{name(8+rs2)}, {uimm},({name(8+rs1)})";
             val offs[XLEN] <= X[rs1+8] + uimm;
@@ -341,7 +339,7 @@ InstructionSet RV64IC extends RV32IC {
         }
         CADDW {//(RV64/128 RV32 res)
             encoding:b100 :: 0b1 :: 0b11 :: rd[2:0] :: 0b01 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";   
+            args_disass: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
             val res[32] <= X[rd+8]{32} + X[rs2+8]{32};
             X[rd+8] <= sext(res);
         }
@@ -351,7 +349,7 @@ InstructionSet RV64IC extends RV32IC {
             if(rs1 != 0){
                 val res[32] <= X[rs1]{32}'s + imm;
                 X[rs1] <= sext(res);
-            } 
+            }
         }
         CSRLI {//(RV64)
             encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
@@ -393,7 +391,6 @@ InstructionSet RV64IC extends RV32IC {
 }
 
 InstructionSet RV128IC extends RV64IC {
-
     instructions{
         CSRLI {//(RV128)
             encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
@@ -416,7 +413,7 @@ InstructionSet RV128IC extends RV64IC {
         CLQ { //(RV128)
              encoding:b001 :: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
         }
-        CSQ { //(RV128) 
+        CSQ { //(RV128)
             encoding:b101 :: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
         }
         CSQSP {//(RV128)

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -3,8 +3,8 @@ import "RISCVBase.core_desc"
 InstructionSet RV32IC extends RISCVBase{
     instructions{
          JALR[[no_cont]]{ // overwriting the implementation if rv32i, alignment does not need to be word
-            encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1100111;
-            args_disass: "{name(rd)}, {name(rs1)}, {imm:#0x}";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1100111;
+            assembly: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
                 int<XLEN> new_pc = X[rs1] + (signed<12>)imm;
                 if(rd!=0) X[rd] = PC+4;
@@ -12,51 +12,51 @@ InstructionSet RV32IC extends RISCVBase{
             }
         }
         CADDI4SPN { //(RES, imm=0)
-            encoding: 0b000 :: imm[5:4] :: imm[9:6] :: imm[2:2] :: imm[3:3] :: rd[2:0] :: 0b00;
-            args_disass: "{name(rd)}, {imm:#05x}";
+            encoding: 3'b000 :: imm[5:4] :: imm[9:6] :: imm[2:2] :: imm[3:3] :: rd[2:0] :: 2'b00;
+            assembly: "{name(rd)}, {imm:#05x}";
             behavior:
                 if(imm) X[rd+8] = X[2] + imm;
                 else raise(0, 2);
         }
         CLW { // (RV32)
-            encoding: 0b010 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 0b00;
-            args_disass: "{name(8+rd)}, {uimm:#05x}({name(8+rs1)})";
+            encoding: 3'b010 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 2'b00;
+            assembly: "{name(8+rd)}, {uimm:#05x}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1+8] + uimm;
                 X[rd+8] = (signed<32>)MEM[load_address];
             }
         }
         CSW {//(RV32)
-            encoding: 0b110 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 0b00;
-            args_disass: "{name(8+rs2)}, {uimm:#05x}({name(8+rs1)})";
+            encoding: 3'b110 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 2'b00;
+            assembly: "{name(8+rs2)}, {uimm:#05x}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1+8] + uimm;
                 MEM[load_address] = X[rs2+8];
             }
         }
         CADDI {//(RV32)
-            encoding: 0b000 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 0b01;
-            args_disass: "{name(rs1)}, {imm:#05x}";
+            encoding: 3'b000 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 2'b01;
+            assembly: "{name(rs1)}, {imm:#05x}";
             behavior: X[rs1] = X[rs1] + (signed<6>)imm;
         }
         CNOP {
-            encoding: 0b000 :: nzimm[5:5] :: 0b00000 :: nzimm[4:0] :: 0b01;
+            encoding: 3'b000 :: nzimm[5:5] :: 5'b00000 :: nzimm[4:0] :: 2'b01;
             behavior: {
                 //if(!nzimm) raise(0, 2);
             }
         }
         // CJAL will be overwritten by CADDIW for RV64/128
         CJAL[[no_cont]] {//(RV32)
-            encoding: 0b001 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 0b01;
-            args_disass: "{imm:#05x}";
+            encoding: 3'b001 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 2'b01;
+            assembly: "{imm:#05x}";
             behavior: {
                 X[1] = PC+2;
                 PC=PC+(signed<12>)imm;
             }
         }
         CLI {//(RV32)
-            encoding: 0b010 :: imm[5:5] :: rd[4:0] :: imm[4:0] :: 0b01;
-            args_disass: "{name(rd)}, {imm:#05x}";
+            encoding: 3'b010 :: imm[5:5] :: rd[4:0] :: imm[4:0] :: 2'b01;
+            assembly: "{name(rd)}, {imm:#05x}";
             behavior: {
                 if(rd != 0)   //rd==0 is a hint, so no trap
                    X[rd] = (unsigned<XLEN>)(signed)imm;
@@ -64,8 +64,8 @@ InstructionSet RV32IC extends RISCVBase{
         }
         // order matters here as CADDI16SP overwrites CLUI for rd==2
         CLUI {//(RV32)
-            encoding: 0b011 :: imm[17:17] :: rd[4:0] :: imm[16:12] :: 0b01;
-            args_disass: "{name(rd)}, {imm:#05x}";
+            encoding: 3'b011 :: imm[17:17] :: rd[4:0] :: imm[16:12] :: 2'b01;
+            assembly: "{name(rd)}, {imm:#05x}";
             behavior: {
                 if(imm == 0) raise(0, 2);
                 if(rd != 0)
@@ -73,27 +73,27 @@ InstructionSet RV32IC extends RISCVBase{
             }
         }
         CADDI16SP {//(RV32)
-            encoding: 0b011 :: nzimm[9:9] :: 0b00010 :: nzimm[4:4] :: nzimm[6:6] :: nzimm[8:7] :: nzimm[5:5] :: 0b01;
-            args_disass: "{nzimm:#05x}";
+            encoding: 3'b011 :: nzimm[9:9] :: 5'b00010 :: nzimm[4:4] :: nzimm[6:6] :: nzimm[8:7] :: nzimm[5:5] :: 2'b01;
+            assembly: "{nzimm:#05x}";
             behavior:
                 if(nzimm) X[2] = X[2] + (signed<10>)nzimm;
                 else raise(0, 2);
         }
         __reserved_clui {//(RV32)
-            encoding: 0b011 :: 0b0 :: rd[4:0] :: 0b00000 :: 0b01;
+            encoding: 3'b011 :: 1'b0 :: rd[4:0] :: 5'b00000 :: 2'b01;
             behavior: raise(0, 2);
         }
         CSRLI {//(RV32 nse)
-            encoding: 0b100 :: 0b0 :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            encoding: 3'b100 :: 1'b0 :: 2'b00 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
+            assembly: "{name(8+rs1)}, {shamt}";
             behavior: {
                 unsigned rs1_idx = rs1+8;
                 X[rs1_idx] = X[rs1_idx] >> shamt;
             }
         }
         CSRAI {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            encoding: 3'b100 :: 1'b0 :: 2'b01 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
+            assembly: "{name(8+rs1)}, {shamt}";
             behavior: if(shamt){
                 unsigned rs1_idx = rs1+8;
                 X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> shamt;
@@ -103,68 +103,68 @@ InstructionSet RV32IC extends RISCVBase{
             }
         }
         CANDI {//(RV32)
-            encoding: 0b100 :: imm[5:5] :: 0b10 :: rs1[2:0] :: imm[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {imm:#05x}";
+            encoding: 3'b100 :: imm[5:5] :: 2'b10 :: rs1[2:0] :: imm[4:0] :: 2'b01;
+            assembly: "{name(8+rs1)}, {imm:#05x}";
             behavior: {
                 unsigned rs1_idx = rs1 + 8;
                 X[rs1_idx] = X[rs1_idx] & (signed<6>)imm;
             }
         }
         CSUB {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b00 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rs2)}";
+            encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b00 :: rs2[2:0] :: 2'b01;
+            assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] - X[rs2 + 8];
             }
         }
         CXOR {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b01 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rs2)}";
+            encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b01 :: rs2[2:0] :: 2'b01;
+            assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] ^ X[rs2 + 8];
             }
         }
         COR {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b10 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rs2)}";
+            encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b10 :: rs2[2:0] :: 2'b01;
+            assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] | X[rs2 + 8];
             }
         }
         CAND {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b11 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rs2)}";
+            encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b11 :: rs2[2:0] :: 2'b01;
+            assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] & X[rs2 + 8];
             }
         }
         CJ[[no_cont]] {//(RV32)
-            encoding: 0b101 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 0b01;
-            args_disass: "{imm:#05x}";
+            encoding: 3'b101 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 2'b01;
+            assembly: "{imm:#05x}";
             behavior: PC=PC + (signed<12>)imm;
         }
         CBEQZ[[no_cont]] [[cond]] {//(RV32)
-            encoding: 0b110 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 0b01;
-            args_disass: "{name(8+rs1)}, {imm:#05x}";
+            encoding: 3'b110 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 2'b01;
+            assembly: "{name(8+rs1)}, {imm:#05x}";
             behavior: if(X[rs1+8]==0) PC = PC + (signed<9>)imm;
         }
         CBNEZ[[no_cont]] [[cond]] {//(RV32)
-            encoding: 0b111 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 0b01;
-            args_disass: "{name(8+rs1)}, {imm:#05x}";
+            encoding: 3'b111 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 2'b01;
+            assembly: "{name(8+rs1)}, {imm:#05x}";
             behavior: if(X[rs1+8]!=0) PC = PC + (signed<9>)imm;
         }
         CSLLI {//(RV32)
-            encoding: 0b000 :: 0b0 :: rs1[4:0] :: nzuimm[4:0] :: 0b10;
-            args_disass: "{name(rs1)}, {nzuimm}";
+            encoding: 3'b000 :: 1'b0 :: rs1[4:0] :: nzuimm[4:0] :: 2'b10;
+            assembly: "{name(rs1)}, {nzuimm}";
             behavior: if(nzuimm) X[rs1] = X[rs1]<< nzuimm;
         }
         CLWSP {//
-            encoding: 0b010 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 0b10;
-            args_disass: "{name(rd)}, sp, {uimm:#05x}";
+            encoding: 3'b010 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 2'b10;
+            assembly: "{name(rd)}, sp, {uimm:#05x}";
             behavior: if(rd){
                 unsigned<XLEN> offs = X[2] + uimm;
                 X[rd] = (signed<32>)MEM[offs];
@@ -173,31 +173,31 @@ InstructionSet RV32IC extends RISCVBase{
         }
         // order matters as CJR is a special case of CMV
         CMV {//(RV32)
-            encoding: 0b100 :: 0b0 :: rd[4:0] :: rs2[4:0] :: 0b10;
-            args_disass: "{name(rd)}, {name(rs2)}";
+            encoding: 3'b100 :: 1'b0 :: rd[4:0] :: rs2[4:0] :: 2'b10;
+            assembly: "{name(rd)}, {name(rs2)}";
             behavior: if(rd!=0) X[rd] = X[rs2];
         }
         CJR[[no_cont]] {//(RV32)
-            encoding: 0b100 :: 0b0 :: rs1[4:0] :: 0b00000 :: 0b10;
-            args_disass: "{name(rs1)}";
+            encoding: 3'b100 :: 1'b0 :: rs1[4:0] :: 5'b00000 :: 2'b10;
+            assembly: "{name(rs1)}";
             behavior: if(rs1)
                 PC = X[rs1] & ~0x1;
             else
                 raise(0,2);
         }
         __reserved_cmv {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b00000 :: 0b00000 :: 0b10;
+            encoding: 3'b100 :: 1'b0 :: 5'b00000 :: 5'b00000 :: 2'b10;
             behavior: raise(0,2);
         }
         // order matters as CEBREAK is a special case of CJALR which is a special case of CADD
         CADD {//(RV32)
-            encoding: 0b100 :: 0b1 :: rd[4:0] :: rs2[4:0] :: 0b10;
-            args_disass: "{name(rd)}, {name(rs2)}";
+            encoding: 3'b100 :: 1'b1 :: rd[4:0] :: rs2[4:0] :: 2'b10;
+            assembly: "{name(rd)}, {name(rs2)}";
             behavior: if(rd!=0) X[rd] = X[rd] + X[rs2];
         }
         CJALR[[no_cont]] {//(RV32)
-            encoding: 0b100 :: 0b1 :: rs1[4:0] :: 0b00000 :: 0b10;
-            args_disass: "{name(rs1)}";
+            encoding: 3'b100 :: 1'b1 :: rs1[4:0] :: 5'b00000 :: 2'b10;
+            assembly: "{name(rs1)}";
             behavior: {
                 signed<XLEN> new_pc = X[rs1];
                 X[1] = PC+2;
@@ -205,19 +205,19 @@ InstructionSet RV32IC extends RISCVBase{
             }
         }
         CEBREAK[[no_cont]] {//(RV32)
-            encoding: 0b100 :: 0b1 :: 0b00000 :: 0b00000 :: 0b10;
+            encoding: 3'b100 :: 1'b1 :: 5'b00000 :: 5'b00000 :: 2'b10;
             behavior:            raise(0, 3);
         }
         CSWSP {//
-            encoding: 0b110 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 0b10;
-            args_disass: "{name(rs2)}, {uimm:#05x}(sp)";
+            encoding: 3'b110 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 2'b10;
+            assembly: "{name(rs2)}, {uimm:#05x}(sp)";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<32>)X[rs2];
             }
         }
         DII[[no_cont]] { // Defined Illegal Instruction
-            encoding: 0b000 :: 0b0 :: 0b00000 :: 0b00000 :: 0b00;
+            encoding: 3'b000 :: 1'b0 :: 5'b00000 :: 5'b00000 :: 2'b00;
             behavior:            raise(0, 2);
         }
     }
@@ -232,8 +232,8 @@ InstructionSet RV32FC extends RISCVBase{
     }
     instructions{
         CFLW {
-            encoding: 0b011 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 0b00;
-            args_disass:"f(8+{rd}), {uimm}({name(8+rs1)})";
+            encoding: 3'b011 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 2'b00;
+            assembly: "f(8+{rd}), {uimm}({name(8+rs1)})";
             val offs[XLEN] <= X[rs1+8]+uimm;
             val res[32] <= MEM[offs]{32};
             if(FLEN==32)
@@ -244,14 +244,14 @@ InstructionSet RV32FC extends RISCVBase{
             }
         }
         CFSW {
-            encoding: 0b111 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 0b00;
-            args_disass:"f(8+{rs2}), {uimm}({name(8+rs1)})";
+            encoding: 3'b111 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 2'b00;
+            assembly: "f(8+{rs2}), {uimm}({name(8+rs1)})";
             val offs[XLEN] <= X[rs1+8]+uimm;
             MEM[offs]{32}<=F[rs2+8]{32};
         }
         CFLWSP {
-            encoding:b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 0b10;
-            args_disass:"f{rd}, {uimm}(x2)";
+            encoding:b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 2'b10;
+            assembly: "f{rd}, {uimm}(x2)";
             val offs[XLEN] <= X[2]+uimm;
             val res[32] <= MEM[offs]{32};
             if(FLEN==32)
@@ -262,8 +262,8 @@ InstructionSet RV32FC extends RISCVBase{
             }
         }
         CFSWSP {
-            encoding:b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 0b10;
-            args_disass:"f{rs2}, {uimm}(x2), ";
+            encoding:b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 2'b10;
+            assembly: "f{rs2}, {uimm}(x2), ";
             val offs[XLEN] <= X[2]+uimm;
             MEM[offs]{32}<=F[rs2]{32};
         }
@@ -279,8 +279,8 @@ InstructionSet RV32DC extends RISCVBase{
     }
     instructions{
         CFLD { //(RV32/64)
-            encoding: 0b001 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
-            args_disass:"f(8+{rd}), {uimm}({name(8+rs1)})";
+            encoding: 3'b001 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
+            assembly: "f(8+{rd}), {uimm}({name(8+rs1)})";
             val offs[XLEN] <= X[rs1+8]+uimm;
             val res[64] <= MEM[offs]{64};
             if(FLEN==64)
@@ -291,14 +291,14 @@ InstructionSet RV32DC extends RISCVBase{
             }
          }
         CFSD { //(RV32/64)
-            encoding: 0b101 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
-            args_disass:"f(8+{rs2}), {uimm}({name(8+rs1)})";
+            encoding: 3'b101 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
+            assembly: "f(8+{rs2}), {uimm}({name(8+rs1)})";
             val offs[XLEN] <= X[rs1+8]+uimm;
             MEM[offs]{64}<=F[rs2+8]{64};
         }
         CFLDSP {//(RV32/64)
-            encoding:b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
-            args_disass:"f{rd}, {uimm}(x2)";
+            encoding:b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 2'b10;
+            assembly: "f{rd}, {uimm}(x2)";
             val offs[XLEN] <= X[2]+uimm;
             val res[64] <= MEM[offs]{64};
             if(FLEN==64)
@@ -309,8 +309,8 @@ InstructionSet RV32DC extends RISCVBase{
             }
         }
         CFSDSP {//(RV32/64)
-            encoding:b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 0b10;
-            args_disass:"f{rs2}, {uimm}(x2), ";
+            encoding:b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 2'b10;
+            assembly: "f{rs2}, {uimm}(x2), ";
             val offs[XLEN] <= X[2]+uimm;
             MEM[offs]{64}<=F[rs2]{64};
         }
@@ -320,70 +320,70 @@ InstructionSet RV32DC extends RISCVBase{
 InstructionSet RV64IC extends RV32IC {
     instructions{
         CLD {//(RV64/128)
-            encoding:b011 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
-            args_disass: "{name(8+rd)}, {uimm},({name(8+rs1)})";
+            encoding:b011 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
+            assembly: "{name(8+rd)}, {uimm},({name(8+rs1)})";
             val offs[XLEN] <= X[rs1+8] + uimm;
             X[rd+8]<=sext(MEM[offs]{64});
         }
         CSD { //(RV64/128)
-            encoding:b111 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
-            args_disass: "{name(8+rs2)}, {uimm},({name(8+rs1)})";
+            encoding:b111 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
+            assembly: "{name(8+rs2)}, {uimm},({name(8+rs1)})";
             val offs[XLEN] <= X[rs1+8] + uimm;
             MEM[offs]{64} <= X[rs2+8];
         }
         CSUBW {//(RV64/128, RV32 res)
-            encoding:b100 :: 0b1 :: 0b11 :: rd[2:0] :: 0b00 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
+            encoding:b100 :: 1'b1 :: 2'b11 :: rd[2:0] :: 2'b00 :: rs2[2:0] :: 2'b01;
+            assembly: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
             val res[32] <= X[rd+8]{32} - X[rs2+8]{32};
             X[rd+8] <= sext(res);
         }
         CADDW {//(RV64/128 RV32 res)
-            encoding:b100 :: 0b1 :: 0b11 :: rd[2:0] :: 0b01 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
+            encoding:b100 :: 1'b1 :: 2'b11 :: rd[2:0] :: 2'b01 :: rs2[2:0] :: 2'b01;
+            assembly: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
             val res[32] <= X[rd+8]{32} + X[rs2+8]{32};
             X[rd+8] <= sext(res);
         }
         CADDIW {//(RV64/128)
-            encoding:b001 :: imm[5:5]s :: rs1[4:0] :: imm[4:0]s :: 0b01;
-            args_disass: "{name(rs1)}, {imm:#05x}";
+            encoding:b001 :: imm[5:5]s :: rs1[4:0] :: imm[4:0]s :: 2'b01;
+            assembly: "{name(rs1)}, {imm:#05x}";
             if(rs1 != 0){
                 val res[32] <= X[rs1]{32}'s + imm;
                 X[rs1] <= sext(res);
             }
         }
         CSRLI {//(RV64)
-            encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            encoding:b100 :: shamt[5:5] :: 2'b00 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
+            assembly: "{name(8+rs1)}, {shamt}";
             val rs1_idx[5] <= rs1+8;
             X[rs1_idx] <= shrl(X[rs1_idx], shamt);
         }
         CSRLI64 {//(RV64)
-            encoding:b1000 :: 0b00 :: rs1[2:0] :: 00000 :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            encoding:b1000 :: 2'b00 :: rs1[2:0] :: 00000 :: 2'b01;
+            assembly: "{name(8+rs1)}, {shamt}";
             val rs1_idx[5] <= rs1+8;
             X[rs1_idx] <= shrl(X[rs1_idx], shamt);
         }
         CSRAI {//(RV64)
-            encoding:b100 :: shamt[5:5] :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            encoding:b100 :: shamt[5:5] :: 2'b01 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
+            assembly: "{name(8+rs1)}, {shamt}";
             val rs1_idx[5] <= rs1+8;
             X[rs1_idx] <= shra(X[rs1_idx], shamt);
         }
         CSLLI {//(RV64)
-            encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 0b10;
-            args_disass: "{name(rs1)}, {shamt}";
+            encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 2'b10;
+            assembly: "{name(rs1)}, {shamt}";
             if(rs1 == 0) raise(0, 2);
             X[rs1] <= shll(X[rs1], shamt);
         }
         CLDSP {//(RV64/128
-            encoding:b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
-            args_disass:"{name(rd)}, {uimm}(sp)";
+            encoding:b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 2'b10;
+            assembly: "{name(rd)}, {uimm}(sp)";
             val offs[XLEN] <= X[2] + uimm;
             if(rd!=0) X[rd]<=sext(MEM[offs]{64});
         }
         CSDSP {//(RV64/128)
-            encoding:b111 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 0b10;
-            args_disass:"{name(rs2)}, {uimm}(sp)";
+            encoding:b111 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 2'b10;
+            assembly: "{name(rs2)}, {uimm}(sp)";
             val offs[XLEN] <= X[2] + uimm;
             MEM[offs]{64} <= X[rs2];
         }
@@ -393,31 +393,31 @@ InstructionSet RV64IC extends RV32IC {
 InstructionSet RV128IC extends RV64IC {
     instructions{
         CSRLI {//(RV128)
-            encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            encoding:b100 :: shamt[5:5] :: 2'b00 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
+            assembly: "{name(8+rs1)}, {shamt}";
             val rs1_idx[5] <= rs1+8;
             X[rs1_idx] <= shrl(X[rs1_idx], shamt);
         }
         CSRAI {//(RV128)
-            encoding:b100 :: shamt[5:5] :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            encoding:b100 :: shamt[5:5] :: 2'b01 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
+            assembly: "{name(8+rs1)}, {shamt}";
             val rs1_idx[5] <= rs1+8;
             X[rs1_idx] <= shra(X[rs1_idx], shamt);
         }
         CSLLI {//(RV128)
-            encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 0b10;
-            args_disass: "{name(rs1)}, {shamt}";
+            encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 2'b10;
+            assembly: "{name(rs1)}, {shamt}";
             if(rs1 == 0) raise(0, 2);
             X[rs1] <= shll(X[rs1], shamt);
         }
         CLQ { //(RV128)
-             encoding:b001 :: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
+             encoding:b001 :: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
         }
         CSQ { //(RV128)
-            encoding:b101 :: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
+            encoding:b101 :: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
         }
         CSQSP {//(RV128)
-            encoding:b101 :: uimm[5:4] :: uimm[9:6] :: rs2[4:0] :: 0b10;
+            encoding:b101 :: uimm[5:4] :: uimm[9:6] :: rs2[4:0] :: 2'b10;
         }
     }
 }

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -28,8 +28,8 @@ InstructionSet RV32D extends RISCVBase{
     }
     instructions{
         FLD {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0000111;
-            args_disass:"f{rd}, {imm}({name(rs1)})";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0000111;
+            assembly: "f{rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 unsigned long res = MEM[offs];
@@ -41,16 +41,16 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FSD {
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: imm[4:0] :: 0b0100111;
-            args_disass:"f{rs2}, {imm}({name(rs1)})";
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: imm[4:0] :: 7'b0100111;
+            assembly: "f{rs2}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 MEM[offs]=F[rs2];
             }
         }
         FMADD_D {
-            encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
             behavior: {
                 //F[rd]f= F[rs1]f * F[rs2]f + F[rs3]f;
                 unsigned long res = fmadd_d((unsigned long)F[rs1], (unsigned long)F[rs2], (unsigned long)F[rs3], 0U, rm<7? rm: (unsigned char)FCSR);
@@ -64,8 +64,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FMSUB_D {
-            encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000111;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000111;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
             behavior: {
                 //F[rd]f=F[rs1]f * F[rs2]f - F[rs3]f;
                 unsigned long res = fmadd_d((unsigned long)F[rs1], (unsigned long)F[rs2], (unsigned long)F[rs3], 1U, rm<7? rm: (unsigned char)FCSR);
@@ -79,8 +79,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FNMADD_D {
-            encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001111;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001111;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
             behavior: {
                 //F[rd]f=-F[rs1]f * F[rs2]f + F[rs3]f;
                 unsigned long res = fmadd_d((unsigned long)F[rs1], (unsigned long)F[rs2], (unsigned long)F[rs3], 2U, rm<7? rm: (unsigned char)FCSR);
@@ -94,8 +94,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FNMSUB_D {
-            encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
             behavior: {
                 //F[rd]f=-F[rs1]f * F[rs2]f - F[rs3]f;
                 unsigned long res = fmadd_d((unsigned long)F[rs1], (unsigned long)F[rs2], (unsigned long)F[rs3], 3U, rm<7? rm: (unsigned char)FCSR);
@@ -109,8 +109,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FADD_D {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
                 unsigned long res = fadd_d((unsigned long)F[rs1], (unsigned long)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -124,8 +124,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FSUB_D {
-            encoding: 0b0000101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
+            encoding: 7'b0000101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
                 unsigned long res = fsub_d((unsigned long)F[rs1], (unsigned long)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -139,8 +139,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FMUL_D {
-            encoding: 0b0001001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
+            encoding: 7'b0001001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
                 unsigned long res = fmul_d((unsigned long)F[rs1], (unsigned long)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -154,8 +154,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FDIV_D {
-            encoding: 0b0001101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
+            encoding: 7'b0001101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
                 unsigned long res = fdiv_d((unsigned long)F[rs1], (unsigned long)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -169,8 +169,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FSQRT_D {
-            encoding: 0b0101101 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            encoding: 7'b0101101 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 //F[rd]f=sqrt(F[rs1]f);
                 unsigned long res = fsqrt_d((unsigned long)F[rs1], rm<7? rm: (unsigned char)FCSR);
@@ -184,8 +184,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FSGNJ_D {
-            encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 unsigned long ONE = 1;
                 unsigned long MSK1 = ONE<<63;
@@ -199,8 +199,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FSGNJN_D {
-            encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 unsigned long ONE = 1;
                 unsigned long MSK1 = ONE<<63;
@@ -214,8 +214,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FSGNJX_D {
-            encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 unsigned long ONE = 1;
                 unsigned long MSK1 = ONE<<63;
@@ -228,8 +228,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FMIN_D  {
-            encoding: 0b0010101 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0010101 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 //F[rd]f= choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
                 unsigned long res = fsel_d((unsigned long)F[rs1], (unsigned long)F[rs2], 0U);
@@ -243,8 +243,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FMAX_D {
-            encoding: 0b0010101 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0010101 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 //F[rd]f= choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
                 unsigned long res = fsel_d((unsigned long)F[rs1], (unsigned long)F[rs2], 1U);
@@ -258,8 +258,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FCVT_S_D {
-            encoding: 0b0100000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}";
+            encoding: 7'b0100000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, f{rs1}";
             behavior: {
                 unsigned res = fconv_d2f(F[rs1], rm);
                 // NaN boxing
@@ -267,8 +267,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FCVT_D_S {
-            encoding: 0b0100001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}";
+            encoding: 7'b0100001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, f{rs1}";
             behavior: {
                 unsigned long res = fconv_f2d((unsigned)F[rs1], rm);
                 if(FLEN==64){
@@ -279,8 +279,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FEQ_D {
-            encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 X[rd]=fcmp_d((unsigned long)F[rs1], (unsigned long)F[rs2], 0U);
                 unsigned flags = fget_flags();
@@ -288,8 +288,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FLT_D {
-            encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 X[rd]=fcmp_d((unsigned long)F[rs1], (unsigned long)F[rs2], 2U);
                 unsigned flags = fget_flags();
@@ -297,8 +297,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FLE_D {
-            encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 X[rd]=fcmp_d((unsigned long)F[rs1], (unsigned long)F[rs2], 1U);
                 unsigned flags = fget_flags();
@@ -306,15 +306,15 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FCLASS_D {
-            encoding: 0b1110001 :: 0b00000 :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}";
+            encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rd)}, f{rs1}";
             behavior: {
                 X[rd]=fclass_d((unsigned long)F[rs1]);
             }
         }
         FCVT_W_D {
-            encoding: 0b1100001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            encoding: 7'b1100001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 X[rd]= fcvt_64_32((unsigned long)F[rs1], 0U, rm);
                 unsigned flags = fget_flags();
@@ -322,8 +322,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FCVT_WU_D {
-            encoding: 0b1100001 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            encoding: 7'b1100001 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 //FIXME: should be zext accodring to spec but needs to be sext according to tests
                 X[rd]= fcvt_64_32((unsigned long)F[rs1], 1U, rm);
@@ -332,8 +332,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FCVT_D_W {
-            encoding: 0b1101001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            encoding: 7'b1101001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
                 unsigned long res = fcvt_32_64((unsigned)X[rs1], 2U, rm);
                 if(FLEN==64)
@@ -344,8 +344,8 @@ InstructionSet RV32D extends RISCVBase{
             }
         }
         FCVT_D_WU {
-            encoding: 0b1101001 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            encoding: 7'b1101001 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
                 unsigned long res =fcvt_32_64((unsigned)X[rs1], 3U, rm);
                 if(FLEN==64)
@@ -360,8 +360,8 @@ InstructionSet RV32D extends RISCVBase{
 InstructionSet RV64D extends RV32D{
     instructions{
         FCVT_L_D {
-            encoding: 0b1100001 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            encoding: 7'b1100001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 X[rd]= fcvt_d((unsigned long)F[rs1], 0U, rm);
                 unsigned flags = fget_flags();
@@ -369,8 +369,8 @@ InstructionSet RV64D extends RV32D{
             }
         }
         FCVT_LU_D {
-            encoding: 0b1100001 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            encoding: 7'b1100001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 X[rd]= fcvt_d((unsigned long)F[rs1], 1U, rm);
                 unsigned flags = fget_flags();
@@ -378,8 +378,8 @@ InstructionSet RV64D extends RV32D{
             }
         }
         FCVT_D_L {
-            encoding: 0b1101001 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            encoding: 7'b1101001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
                 unsigned long res = fcvt_d(X[rs1], 2U, rm);
                 if(FLEN==64)
@@ -390,8 +390,8 @@ InstructionSet RV64D extends RV32D{
             }
         }
         FCVT_D_LU {
-            encoding: 0b1101001 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            encoding: 7'b1101001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
                 unsigned long res =fcvt_d(X[rs1], 3U, rm);
                 if(FLEN==64)
@@ -402,15 +402,15 @@ InstructionSet RV64D extends RV32D{
             }
         }
         FMV_X_D {
-            encoding: 0b1110001 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}";
+            encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rd)}, f{rs1}";
             behavior: {
                 X[rd]=F[rs1]; //FIXME: sign extend
             }
         }
         FMV_D_X {
-            encoding: 0b1111001 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, {name(rs1)}";
+            encoding: 7'b1111001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, {name(rs1)}";
             behavior: {
                 F[rd] = X[rs1];
             }

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -5,10 +5,9 @@ InstructionSet RV32D extends RISCVBase{
     architectural_state {
         unsigned FLEN;
         unsigned FFLAG_MASK = 0x1f;
-
-	   	unsigned<FLEN> F[32];
-       	unsigned<32> FCSR;
-    }    
+        unsigned<FLEN> F[32];
+        unsigned<32> FCSR;
+    }
     functions {
         extern unsigned fadd_d(unsigned, unsigned, unsigned char);
         extern unsigned fsub_d(unsigned, unsigned, unsigned char);
@@ -359,7 +358,6 @@ InstructionSet RV32D extends RISCVBase{
     }
 }
 InstructionSet RV64D extends RV32D{
-
     instructions{
         FCVT_L_D {
             encoding: 0b1100001 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
@@ -419,5 +417,4 @@ InstructionSet RV64D extends RV32D{
         }
     }
 }
-    
-    
+

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -3,28 +3,28 @@ import "RISCVBase.core_desc"
 // TODO: review instruction description wrt. Spec after type system is fixed
 InstructionSet RV32D extends RISCVBase{
     architectural_state {
-        unsigned FLEN;
-        unsigned FFLAG_MASK = 0x1f;
+        unsigned int FLEN;
+        unsigned int FFLAG_MASK = 0x1f;
         unsigned<FLEN> F[32];
         unsigned<32> FCSR;
     }
     functions {
-        extern unsigned fadd_d(unsigned, unsigned, unsigned char);
-        extern unsigned fsub_d(unsigned, unsigned, unsigned char);
-        extern unsigned fmul_d(unsigned, unsigned, unsigned char);
-        extern unsigned fdiv_d(unsigned, unsigned, unsigned char);
-        extern unsigned fmadd_d(unsigned, unsigned, unsigned, unsigned, unsigned char);
-        extern unsigned fsel_d(unsigned, unsigned, unsigned);
-        extern unsigned fsqrt_d(unsigned, unsigned char);
-        extern unsigned fcmp_d(unsigned, unsigned, unsigned);
-        extern unsigned fcvt_d(unsigned, unsigned, unsigned char);
-        extern unsigned fconv_d2f(unsigned long);
-        extern unsigned long fconv_f2d(unsigned);
-        extern unsigned long fcvt_32_64(unsigned, unsigned, unsigned char);
-        extern unsigned long fcvt_64_32(unsigned, unsigned, unsigned char);
-        extern unsigned unbox_d(unsigned long);
-        extern unsigned fclass_d(unsigned);
-        extern unsigned fget_flags();
+        extern unsigned int fadd_d(unsigned int, unsigned int, unsigned char);
+        extern unsigned int fsub_d(unsigned int, unsigned int, unsigned char);
+        extern unsigned int fmul_d(unsigned int, unsigned int, unsigned char);
+        extern unsigned int fdiv_d(unsigned int, unsigned int, unsigned char);
+        extern unsigned int fmadd_d(unsigned int, unsigned int, unsigned int, unsigned int, unsigned char);
+        extern unsigned int fsel_d(unsigned int, unsigned int, unsigned int);
+        extern unsigned int fsqrt_d(unsigned int, unsigned char);
+        extern unsigned int fcmp_d(unsigned int, unsigned int, unsigned int);
+        extern unsigned int fcvt_d(unsigned int, unsigned int, unsigned char);
+        extern unsigned int fconv_d2f(unsigned long);
+        extern unsigned long fconv_f2d(unsigned int);
+        extern unsigned long fcvt_32_64(unsigned int, unsigned int, unsigned char);
+        extern unsigned long fcvt_64_32(unsigned int, unsigned int, unsigned char);
+        extern unsigned int unbox_d(unsigned long);
+        extern unsigned int fclass_d(unsigned int);
+        extern unsigned int fget_flags();
     }
     instructions{
         FLD {
@@ -59,7 +59,7 @@ InstructionSet RV32D extends RISCVBase{
                 else { // NaN boxing
                     F[rd] = (-1LL<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -74,7 +74,7 @@ InstructionSet RV32D extends RISCVBase{
                 else { // NaN boxing
                     F[rd] = (-1LL<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -89,7 +89,7 @@ InstructionSet RV32D extends RISCVBase{
                 else { // NaN boxing
                     F[rd] = (-1LL<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -104,7 +104,7 @@ InstructionSet RV32D extends RISCVBase{
                 else { // NaN boxing
                     F[rd] = (-1LL<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -119,7 +119,7 @@ InstructionSet RV32D extends RISCVBase{
                 else { // NaN boxing
                     F[rd] = (-1LL<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -134,7 +134,7 @@ InstructionSet RV32D extends RISCVBase{
                 else { // NaN boxing
                     F[rd] = (-1LL<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -149,7 +149,7 @@ InstructionSet RV32D extends RISCVBase{
                 else { // NaN boxing
                     F[rd] = (-1LL<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -164,7 +164,7 @@ InstructionSet RV32D extends RISCVBase{
                 else { // NaN boxing
                     F[rd] = (-1LL<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -179,7 +179,7 @@ InstructionSet RV32D extends RISCVBase{
                 else { // NaN boxing
                     F[rd] = (-1LL<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -238,7 +238,7 @@ InstructionSet RV32D extends RISCVBase{
                 else { // NaN boxing
                     F[rd] = (-1LL<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -253,7 +253,7 @@ InstructionSet RV32D extends RISCVBase{
                 else { // NaN boxing
                     F[rd] = (-1LL<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -261,7 +261,7 @@ InstructionSet RV32D extends RISCVBase{
             encoding: 7'b0100000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly: "{name(rm)}, f{rd}, f{rs1}";
             behavior: {
-                unsigned res = fconv_d2f(F[rs1], rm);
+                unsigned int res = fconv_d2f(F[rs1], rm);
                 // NaN boxing
                 F[rd] = (-1LL<<64) + res;
             }
@@ -283,7 +283,7 @@ InstructionSet RV32D extends RISCVBase{
             assembly: "{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 X[rd]=fcmp_d((unsigned long)F[rs1], (unsigned long)F[rs2], 0U);
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -292,7 +292,7 @@ InstructionSet RV32D extends RISCVBase{
             assembly: "{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 X[rd]=fcmp_d((unsigned long)F[rs1], (unsigned long)F[rs2], 2U);
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -301,7 +301,7 @@ InstructionSet RV32D extends RISCVBase{
             assembly: "{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 X[rd]=fcmp_d((unsigned long)F[rs1], (unsigned long)F[rs2], 1U);
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -317,7 +317,7 @@ InstructionSet RV32D extends RISCVBase{
             assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 X[rd]= fcvt_64_32((unsigned long)F[rs1], 0U, rm);
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -327,7 +327,7 @@ InstructionSet RV32D extends RISCVBase{
             behavior: {
                 //FIXME: should be zext accodring to spec but needs to be sext according to tests
                 X[rd]= fcvt_64_32((unsigned long)F[rs1], 1U, rm);
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -364,7 +364,7 @@ InstructionSet RV64D extends RV32D{
             assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 X[rd]= fcvt_d((unsigned long)F[rs1], 0U, rm);
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -373,7 +373,7 @@ InstructionSet RV64D extends RV32D{
             assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 X[rd]= fcvt_d((unsigned long)F[rs1], 1U, rm);
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -26,8 +26,8 @@ InstructionSet RV32F extends RV32I{
     }
     instructions{
         FLW {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0000111;
-            args_disass:"f{rd}, {imm}({name(rs1)})";
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0000111;
+            assembly: "f{rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 unsigned<XLEN> res = MEM[offs];
@@ -39,16 +39,16 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FSW {
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: imm[4:0] :: 0b0100111;
-            args_disass:"f{rs2}, {imm}({name(rs1)])";
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: imm[4:0] :: 7'b0100111;
+            assembly: "f{rs2}, {imm}({name(rs1)])";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 MEM[offs]=F[rs2];
             }
         }
         FMADD_S {
-            encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
             behavior: {
                 //F[rd]f= F[rs1]f * F[rs2]f + F[rs3]f;
                 if(FLEN==32)
@@ -62,8 +62,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FMSUB_S {
-            encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000111;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000111;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
             behavior: {
                 //F[rd]f=F[rs1]f * F[rs2]f - F[rs3]f;
                 if(FLEN==32)
@@ -77,8 +77,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FNMADD_S {
-            encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001111;
-            args_disass:"{name(rm)}, name(rd), f{rs1}, f{rs2}, f{rs3}";
+            encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001111;
+            assembly: "{name(rm)}, name(rd), f{rs1}, f{rs2}, f{rs3}";
             behavior: {
                 //F[rd]f=-F[rs1]f * F[rs2]f + F[rs3]f;
                 if(FLEN==32)
@@ -95,8 +95,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FNMSUB_S {
-            encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
             behavior: {
             //F[rd]f=-F[rs1]f * F[rs2]f - F[rs3]f;
                 if(FLEN==32)
@@ -113,8 +113,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FADD_S {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
                 if(FLEN==32)
@@ -130,8 +130,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FSUB_S {
-            encoding: 0b0000100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0000100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
                 if(FLEN==32)
@@ -147,8 +147,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FMUL_S {
-            encoding: 0b0001000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0001000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
                 if(FLEN==32)
@@ -164,8 +164,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FDIV_S {
-            encoding: 0b0001100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0001100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
                 if(FLEN==32)
@@ -181,8 +181,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FSQRT_S {
-            encoding: 0b0101100 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}";
+            encoding: 7'b0101100 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, f{rs1}";
             behavior: {
                 //F[rd]f=sqrt(F[rs1]f);
                 if(FLEN==32)
@@ -197,8 +197,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FSGNJ_S {
-            encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
                     F[rd] = (F[rs1] & 0x7fffffff) :: (F[rs2] & 0x80000000);
@@ -211,8 +211,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FSGNJN_S {
-            encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
                     F[rd] = (F[rs1] & 0x7fffffff) :: (~F[rs2] & 0x80000000);
@@ -225,8 +225,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FSGNJX_S {
-            encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
                     F[rd] = F[rs1] ^ (F[rs2] & 0x80000000);
@@ -239,8 +239,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FMIN_S  {
-            encoding: 0b0010100 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0010100 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 //F[rd]f= choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
                 if(FLEN==32)
@@ -256,8 +256,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FMAX_S {
-            encoding: 0b0010100 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            encoding: 7'b0010100 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 //F[rd]f= choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
                 if(FLEN==32)
@@ -273,8 +273,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FCVT_W_S {
-            encoding: 0b1100000 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            encoding: 7'b1100000 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 if(FLEN==32)
                     X[rd] = fcvt_s(F[rs1], 0U, rm);
@@ -287,8 +287,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FCVT_WU_S {
-            encoding: 0b1100000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            encoding: 7'b1100000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 //FIXME: according to the spec it should be zero-extended not sign extended
                 if(FLEN==32)
@@ -302,8 +302,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FEQ_S {
-            encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
                     X[rd]=fcmp_s(F[rs1], F[rs2], 0U);
@@ -317,8 +317,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FLT_S {
-            encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
                     X[rd]=fcmp_s(F[rs1], F[rs2], 2U);
@@ -333,8 +333,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FLE_S {
-            encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
                     X[rd]=fcmp_s(F[rs1], F[rs2], 1U);
@@ -348,15 +348,15 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FCLASS_S {
-            encoding: 0b1110000 :: 0b00000 :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}";
+            encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rd)}, f{rs1}";
             behavior: {
                 X[rd]=fclass_s(unbox_s(F[rs1]));
             }
         }
         FCVT_S_W {
-            encoding: 0b1101000 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            encoding: 7'b1101000 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
                 if(FLEN==32)
                     F[rd]  = fcvt_s((unsigned)X[rs1], 2U, rm);
@@ -367,8 +367,8 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FCVT_S_WU {
-            encoding: 0b1101000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            encoding: 7'b1101000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
                 if(FLEN==32)
                     F[rd]  =fcvt_s((unsigned)X[rs1], 3U, rm);
@@ -379,15 +379,15 @@ InstructionSet RV32F extends RV32I{
             }
         }
         FMV_X_W {
-            encoding: 0b1110000 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}";
+            encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rd)}, f{rs1}";
             behavior: {
                 X[rd]=F[rs1];
             }
         }
         FMV_W_X {
-            encoding: 0b1111000 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, {name(rs1)}";
+            encoding: 7'b1111000 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
+            assembly: "f{rd}, {name(rs1)}";
             behavior: {
                 if(FLEN==32)
                     F[rd] = X[rs1];
@@ -402,8 +402,8 @@ InstructionSet RV32F extends RV32I{
 InstructionSet RV64F extends RV32F{
     instructions{
         FCVT_L_S { // fp to 64bit signed integer
-            encoding: 0b1100000 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            encoding: 7'b1100000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 unsigned long res = fcvt_32_64(unbox_s(F[rs1]), 0U, rm);
                 X[rd]= res;
@@ -412,8 +412,8 @@ InstructionSet RV64F extends RV32F{
             }
         }
         FCVT_LU_S { // fp to 64bit unsigned integer
-            encoding: 0b1100000 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            encoding: 7'b1100000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 unsigned long res = fcvt_32_64(unbox_s(F[rs1]), 1U, rm);
                 X[rd]= res;
@@ -422,8 +422,8 @@ InstructionSet RV64F extends RV32F{
             }
         }
         FCVT_S_L { // 64bit signed int to to fp
-            encoding: 0b1101000 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            encoding: 7'b1101000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
                 unsigned res = fcvt_64_32(X[rs1], 2U, rm);
                 if(FLEN==32)
@@ -434,8 +434,8 @@ InstructionSet RV64F extends RV32F{
             }
         }
         FCVT_S_LU { // 64bit unsigned int to to fp
-            encoding: 0b1101000 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            encoding: 7'b1101000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
+            assembly: "{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
                 unsigned res =fcvt_64_32(X[rs1], 3U, rm);
                 if(FLEN==32)

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -3,26 +3,26 @@ import "RV32I.core_desc"
 // TODO: review instruction description wrt. Spec after type system is fixed
 InstructionSet RV32F extends RV32I{
     architectural_state {
-        unsigned FLEN;
-        unsigned FFLAG_MASK = 0x1f;
+        unsigned int FLEN;
+        unsigned int FFLAG_MASK = 0x1f;
         unsigned<FLEN> F[32];
         unsigned<32> FCSR;
     }
     functions {
-        extern unsigned fadd_s(unsigned, unsigned, unsigned char);
-        extern unsigned fsub_s(unsigned, unsigned, unsigned char);
-        extern unsigned fmul_s(unsigned, unsigned, unsigned char);
-        extern unsigned fdiv_s(unsigned, unsigned, unsigned char);
-        extern unsigned fmadd_s(unsigned, unsigned, unsigned, unsigned, unsigned char);
-        extern unsigned fsel_s(unsigned, unsigned, unsigned);
-        extern unsigned fsqrt_s(unsigned, unsigned char);
-        extern unsigned fcmp_s(unsigned, unsigned, unsigned);
-        extern unsigned fcvt_s(unsigned, unsigned, unsigned char);
-        extern unsigned long fcvt_32_64(unsigned, unsigned, unsigned char);
-        extern unsigned long fcvt_64_32(unsigned, unsigned, unsigned char);
-        extern unsigned unbox_s(unsigned long);
-        extern unsigned fclass_s(unsigned);
-        extern unsigned fget_flags();
+        extern unsigned int fadd_s(unsigned int, unsigned int, unsigned char);
+        extern unsigned int fsub_s(unsigned int, unsigned int, unsigned char);
+        extern unsigned int fmul_s(unsigned int, unsigned int, unsigned char);
+        extern unsigned int fdiv_s(unsigned int, unsigned int, unsigned char);
+        extern unsigned int fmadd_s(unsigned int, unsigned int, unsigned int, unsigned int, unsigned char);
+        extern unsigned int fsel_s(unsigned int, unsigned int, unsigned int);
+        extern unsigned int fsqrt_s(unsigned int, unsigned char);
+        extern unsigned int fcmp_s(unsigned int, unsigned int, unsigned int);
+        extern unsigned int fcvt_s(unsigned int, unsigned int, unsigned char);
+        extern unsigned long fcvt_32_64(unsigned int, unsigned int, unsigned char);
+        extern unsigned long fcvt_64_32(unsigned int, unsigned int, unsigned char);
+        extern unsigned int unbox_s(unsigned long);
+        extern unsigned int fclass_s(unsigned int);
+        extern unsigned int fget_flags();
     }
     instructions{
         FLW {
@@ -54,10 +54,10 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 0, rm<7? (unsigned char)rm:(unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned res = fmadd_s(unbox_s(F[rs1]), unbox_s(F[rs2]), unbox_s(F[rs3]), 0, rm<7? rm: (unsigned char)FCSR);
+                    unsigned int res = fmadd_s(unbox_s(F[rs1]), unbox_s(F[rs2]), unbox_s(F[rs3]), 0, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -69,10 +69,10 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 1UL, rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned res = fmadd_s(unbox_s(F[rs1]), unbox_s(F[rs2]), unbox_s(F[rs3]), 1U, rm<7? rm: (unsigned char)FCSR);
+                    unsigned int res = fmadd_s(unbox_s(F[rs1]), unbox_s(F[rs2]), unbox_s(F[rs3]), 1U, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -84,13 +84,13 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 2U, rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned frs3 = unbox_s(F[rs3]);
-                    unsigned res = fmadd_s(frs1, frs2, frs3, 2U, rm<7? rm: (unsigned char)FCSR);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
+                    unsigned int frs3 = unbox_s(F[rs3]);
+                    unsigned int res = fmadd_s(frs1, frs2, frs3, 2U, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -102,13 +102,13 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 3U, rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned frs3 = unbox_s(F[rs3]);
-                    unsigned res = fmadd_s(frs1, frs2, frs3, 3U, rm<7? rm: (unsigned char)FCSR);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
+                    unsigned int frs3 = unbox_s(F[rs3]);
+                    unsigned int res = fmadd_s(frs1, frs2, frs3, 3U, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -120,12 +120,12 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fadd_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fadd_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
+                    unsigned int res = fadd_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -137,12 +137,12 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fsub_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fsub_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
+                    unsigned int res = fsub_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -154,12 +154,12 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fmul_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fmul_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
+                    unsigned int res = fmul_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -171,12 +171,12 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fdiv_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fdiv_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
+                    unsigned int res = fdiv_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -188,11 +188,11 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fsqrt_s(F[rs1], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned res = fsqrt_s(frs1, rm<7? rm: (unsigned char)FCSR);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int res = fsqrt_s(frs1, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -203,9 +203,9 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = (F[rs1] & 0x7fffffff) :: (F[rs2] & 0x80000000);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = (frs1 & 0x7fffffff) :: (frs2 & 0x80000000);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
+                    unsigned int res = (frs1 & 0x7fffffff) :: (frs2 & 0x80000000);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
             }
@@ -217,9 +217,9 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = (F[rs1] & 0x7fffffff) :: (~F[rs2] & 0x80000000);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = (frs1 & 0x7fffffff) :: (~frs2 & 0x80000000);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
+                    unsigned int res = (frs1 & 0x7fffffff) :: (~frs2 & 0x80000000);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
             }
@@ -231,9 +231,9 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = F[rs1] ^ (F[rs2] & 0x80000000);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = frs1 ^ (frs2 & 0x80000000);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
+                    unsigned int res = frs1 ^ (frs2 & 0x80000000);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
             }
@@ -246,12 +246,12 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fsel_s(F[rs1], F[rs2], 0U);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fsel_s(frs1, frs2, 0U);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
+                    unsigned int res = fsel_s(frs1, frs2, 0U);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -263,12 +263,12 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fsel_s(F[rs1], F[rs2], 1U);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fsel_s(frs1, frs2, 1U);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
+                    unsigned int res = fsel_s(frs1, frs2, 1U);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -279,10 +279,10 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     X[rd] = fcvt_s(F[rs1], 0U, rm);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned int frs1 = unbox_s(F[rs1]);
                     X[rd]= fcvt_s(frs1, 0U, rm);
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -294,10 +294,10 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                      X[rd]= fcvt_s(F[rs1], 1U, rm);
                 else { // NaN boxing
-                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned int frs1 = unbox_s(F[rs1]);
                     X[rd]= fcvt_s(frs1, 1U, rm);
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -308,11 +308,11 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     X[rd]=fcmp_s(F[rs1], F[rs2], 0U);
                 else {
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
                     X[rd]=fcmp_s(frs1, frs2, 0U);
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -323,12 +323,12 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     X[rd]=fcmp_s(F[rs1], F[rs2], 2U);
                 else {
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
                     X[rd]=fcmp_s(frs1, frs2, 2U);
                 }
                 X[rd]=fcmp_s((unsigned)F[rs1], (unsigned)F[rs2], 2U);
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -339,11 +339,11 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     X[rd]=fcmp_s(F[rs1], F[rs2], 1U);
                 else {
-                    unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned int frs1 = unbox_s(F[rs1]);
+                    unsigned int frs2 = unbox_s(F[rs2]);
                     X[rd]=fcmp_s(frs1, frs2, 1U);
                 }
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -361,7 +361,7 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd]  = fcvt_s((unsigned)X[rs1], 2U, rm);
                 else { // NaN boxing
-                    unsigned res = fcvt_s((unsigned)X[rs1], 2U, rm);
+                    unsigned int res = fcvt_s((unsigned)X[rs1], 2U, rm);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
             }
@@ -373,7 +373,7 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd]  =fcvt_s((unsigned)X[rs1], 3U, rm);
                 else { // NaN boxing
-                    unsigned res =fcvt_s((unsigned)X[rs1], 3U, rm);
+                    unsigned int res =fcvt_s((unsigned)X[rs1], 3U, rm);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
             }
@@ -407,7 +407,7 @@ InstructionSet RV64F extends RV32F{
             behavior: {
                 unsigned long res = fcvt_32_64(unbox_s(F[rs1]), 0U, rm);
                 X[rd]= res;
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -417,7 +417,7 @@ InstructionSet RV64F extends RV32F{
             behavior: {
                 unsigned long res = fcvt_32_64(unbox_s(F[rs1]), 1U, rm);
                 X[rd]= res;
-                unsigned flags = fget_flags();
+                unsigned int flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
@@ -425,7 +425,7 @@ InstructionSet RV64F extends RV32F{
             encoding: 7'b1101000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly: "{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
-                unsigned res = fcvt_64_32(X[rs1], 2U, rm);
+                unsigned int res = fcvt_64_32(X[rs1], 2U, rm);
                 if(FLEN==32)
                     F[rd] = res;
                 else { // NaN boxing
@@ -437,7 +437,7 @@ InstructionSet RV64F extends RV32F{
             encoding: 7'b1101000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly: "{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
-                unsigned res =fcvt_64_32(X[rs1], 3U, rm);
+                unsigned int res =fcvt_64_32(X[rs1], 3U, rm);
                 if(FLEN==32)
                     F[rd] = res;
                 else { // NaN boxing

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -5,10 +5,9 @@ InstructionSet RV32F extends RV32I{
     architectural_state {
         unsigned FLEN;
         unsigned FFLAG_MASK = 0x1f;
-
-	   	unsigned<FLEN> F[32];
-       	unsigned<32> FCSR;
-    }    
+        unsigned<FLEN> F[32];
+        unsigned<32> FCSR;
+    }
     functions {
         extern unsigned fadd_s(unsigned, unsigned, unsigned char);
         extern unsigned fsub_s(unsigned, unsigned, unsigned char);
@@ -53,9 +52,9 @@ InstructionSet RV32F extends RV32I{
             behavior: {
                 //F[rd]f= F[rs1]f * F[rs2]f + F[rs3]f;
                 if(FLEN==32)
-    	            F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 0, rm<7? (unsigned char)rm:(unsigned char)FCSR);
+                    F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 0, rm<7? (unsigned char)rm:(unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned res = fmadd_s(unbox_s(F[rs1]), unbox_s(F[rs2]), unbox_s(F[rs3]), 0, rm<7? rm: (unsigned char)FCSR);            
+                    unsigned res = fmadd_s(unbox_s(F[rs1]), unbox_s(F[rs2]), unbox_s(F[rs3]), 0, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
                 unsigned flags = fget_flags();
@@ -68,7 +67,7 @@ InstructionSet RV32F extends RV32I{
             behavior: {
                 //F[rd]f=F[rs1]f * F[rs2]f - F[rs3]f;
                 if(FLEN==32)
-    	            F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 1UL, rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 1UL, rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
                     unsigned res = fmadd_s(unbox_s(F[rs1]), unbox_s(F[rs2]), unbox_s(F[rs3]), 1U, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
@@ -85,9 +84,9 @@ InstructionSet RV32F extends RV32I{
                 if(FLEN==32)
                     F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 2U, rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-    	            unsigned frs3 = unbox_s(F[rs3]);
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned frs3 = unbox_s(F[rs3]);
                     unsigned res = fmadd_s(frs1, frs2, frs3, 2U, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -101,11 +100,11 @@ InstructionSet RV32F extends RV32I{
             behavior: {
             //F[rd]f=-F[rs1]f * F[rs2]f - F[rs3]f;
                 if(FLEN==32)
-    	            F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 3U, rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 3U, rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-    	            unsigned frs3 = unbox_s(F[rs3]);
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned frs3 = unbox_s(F[rs3]);
                     unsigned res = fmadd_s(frs1, frs2, frs3, 3U, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -119,10 +118,10 @@ InstructionSet RV32F extends RV32I{
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
                 if(FLEN==32)
-    	            F[rd] = fadd_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = fadd_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
                     unsigned res = fadd_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -136,10 +135,10 @@ InstructionSet RV32F extends RV32I{
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
                 if(FLEN==32)
-    	            F[rd] = fsub_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = fsub_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
                     unsigned res = fsub_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -153,10 +152,10 @@ InstructionSet RV32F extends RV32I{
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
                 if(FLEN==32)
-    	            F[rd] = fmul_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = fmul_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
                     unsigned res = fmul_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -170,10 +169,10 @@ InstructionSet RV32F extends RV32I{
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
                 if(FLEN==32)
-    	            F[rd] = fdiv_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = fdiv_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
                     unsigned res = fdiv_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -187,9 +186,9 @@ InstructionSet RV32F extends RV32I{
             behavior: {
                 //F[rd]f=sqrt(F[rs1]f);
                 if(FLEN==32)
-    	            F[rd] = fsqrt_s(F[rs1], rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = fsqrt_s(F[rs1], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs1 = unbox_s(F[rs1]);
                     unsigned res = fsqrt_s(frs1, rm<7? rm: (unsigned char)FCSR);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -202,10 +201,10 @@ InstructionSet RV32F extends RV32I{
             args_disass:"f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
-    	            F[rd] = (F[rs1] & 0x7fffffff) :: (F[rs2] & 0x80000000);
+                    F[rd] = (F[rs1] & 0x7fffffff) :: (F[rs2] & 0x80000000);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
                     unsigned res = (frs1 & 0x7fffffff) :: (frs2 & 0x80000000);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -216,10 +215,10 @@ InstructionSet RV32F extends RV32I{
             args_disass:"f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
-    	            F[rd] = (F[rs1] & 0x7fffffff) :: (~F[rs2] & 0x80000000);
+                    F[rd] = (F[rs1] & 0x7fffffff) :: (~F[rs2] & 0x80000000);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
                     unsigned res = (frs1 & 0x7fffffff) :: (~frs2 & 0x80000000);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -230,10 +229,10 @@ InstructionSet RV32F extends RV32I{
             args_disass:"f{rd}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
-    	            F[rd] = F[rs1] ^ (F[rs2] & 0x80000000);
+                    F[rd] = F[rs1] ^ (F[rs2] & 0x80000000);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
                     unsigned res = frs1 ^ (frs2 & 0x80000000);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -245,10 +244,10 @@ InstructionSet RV32F extends RV32I{
             behavior: {
                 //F[rd]f= choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
                 if(FLEN==32)
-    	            F[rd] = fsel_s(F[rs1], F[rs2], 0U);
+                    F[rd] = fsel_s(F[rs1], F[rs2], 0U);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
                     unsigned res = fsel_s(frs1, frs2, 0U);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -262,10 +261,10 @@ InstructionSet RV32F extends RV32I{
             behavior: {
                 //F[rd]f= choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
                 if(FLEN==32)
-    	            F[rd] = fsel_s(F[rs1], F[rs2], 1U);
+                    F[rd] = fsel_s(F[rs1], F[rs2], 1U);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
                     unsigned res = fsel_s(frs1, frs2, 1U);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
                 }
@@ -278,9 +277,9 @@ InstructionSet RV32F extends RV32I{
             args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
             behavior: {
                 if(FLEN==32)
-    	            X[rd] = fcvt_s(F[rs1], 0U, rm);
+                    X[rd] = fcvt_s(F[rs1], 0U, rm);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs1 = unbox_s(F[rs1]);
                     X[rd]= fcvt_s(frs1, 0U, rm);
                 }
                 unsigned flags = fget_flags();
@@ -293,9 +292,9 @@ InstructionSet RV32F extends RV32I{
             behavior: {
                 //FIXME: according to the spec it should be zero-extended not sign extended
                 if(FLEN==32)
-               		 X[rd]= fcvt_s(F[rs1], 1U, rm);
+                     X[rd]= fcvt_s(F[rs1], 1U, rm);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs1 = unbox_s(F[rs1]);
                     X[rd]= fcvt_s(frs1, 1U, rm);
                 }
                 unsigned flags = fget_flags();
@@ -307,12 +306,12 @@ InstructionSet RV32F extends RV32I{
             args_disass:"{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
-    	            X[rd]=fcmp_s(F[rs1], F[rs2], 0U);
-    	        else {
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-    	            X[rd]=fcmp_s(frs1, frs2, 0U);	        
-    	        }
+                    X[rd]=fcmp_s(F[rs1], F[rs2], 0U);
+                else {
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
+                    X[rd]=fcmp_s(frs1, frs2, 0U);
+                }
                 unsigned flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -322,11 +321,11 @@ InstructionSet RV32F extends RV32I{
             args_disass:"{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
-                	X[rd]=fcmp_s(F[rs1], F[rs2], 2U);
-    	        else {
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-                	X[rd]=fcmp_s(frs1, frs2, 2U);
+                    X[rd]=fcmp_s(F[rs1], F[rs2], 2U);
+                else {
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
+                    X[rd]=fcmp_s(frs1, frs2, 2U);
                 }
                 X[rd]=fcmp_s((unsigned)F[rs1], (unsigned)F[rs2], 2U);
                 unsigned flags = fget_flags();
@@ -338,12 +337,12 @@ InstructionSet RV32F extends RV32I{
             args_disass:"{name(rd)}, f{rs1}, f{rs2}";
             behavior: {
                 if(FLEN==32)
-    	            X[rd]=fcmp_s(F[rs1], F[rs2], 1U);
-    	        else {
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-    	            X[rd]=fcmp_s(frs1, frs2, 1U);
-    	        }
+                    X[rd]=fcmp_s(F[rs1], F[rs2], 1U);
+                else {
+                    unsigned frs1 = unbox_s(F[rs1]);
+                    unsigned frs2 = unbox_s(F[rs2]);
+                    X[rd]=fcmp_s(frs1, frs2, 1U);
+                }
                 unsigned flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -360,7 +359,7 @@ InstructionSet RV32F extends RV32I{
             args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
                 if(FLEN==32)
-    	            F[rd]  = fcvt_s((unsigned)X[rs1], 2U, rm);
+                    F[rd]  = fcvt_s((unsigned)X[rs1], 2U, rm);
                 else { // NaN boxing
                     unsigned res = fcvt_s((unsigned)X[rs1], 2U, rm);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
@@ -372,7 +371,7 @@ InstructionSet RV32F extends RV32I{
             args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
                 if(FLEN==32)
-        	        F[rd]  =fcvt_s((unsigned)X[rs1], 3U, rm);
+                    F[rd]  =fcvt_s((unsigned)X[rs1], 3U, rm);
                 else { // NaN boxing
                     unsigned res =fcvt_s((unsigned)X[rs1], 3U, rm);
                     F[rd] = (-1<<32) | (unsigned<FLEN>)res;
@@ -401,7 +400,6 @@ InstructionSet RV32F extends RV32I{
 }
 
 InstructionSet RV64F extends RV32F{
-
     instructions{
         FCVT_L_S { // fp to 64bit signed integer
             encoding: 0b1100000 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
@@ -423,7 +421,7 @@ InstructionSet RV64F extends RV32F{
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
-        FCVT_S_L { // 64bit signed int to to fp 
+        FCVT_S_L { // 64bit signed int to to fp
             encoding: 0b1101000 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
             args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
@@ -435,7 +433,7 @@ InstructionSet RV64F extends RV32F{
                 }
             }
         }
-        FCVT_S_LU { // 64bit unsigned int to to fp 
+        FCVT_S_LU { // 64bit unsigned int to to fp
             encoding: 0b1101000 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
             args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
             behavior: {
@@ -447,6 +445,5 @@ InstructionSet RV64F extends RV32F{
                 }
             }
         }
-	}
+    }
 }
-    

--- a/RVM.core_desc
+++ b/RVM.core_desc
@@ -2,7 +2,7 @@ import "RISCVBase.core_desc"
 
 InstructionSet RV32M extends RISCVBase {
     architectural_state {
-        unsigned MUL_LEN=2*XLEN;
+        unsigned int MUL_LEN=2*XLEN;
     }
     instructions{
         MUL{

--- a/RVM.core_desc
+++ b/RVM.core_desc
@@ -4,61 +4,61 @@ InstructionSet RV32M extends RISCVBase {
     architectural_state {
         unsigned MUL_LEN=2*XLEN;
     }
-    instructions{       
+    instructions{
         MUL{
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
-	                X[rd]= (unsigned<XLEN>)res;
-	            }
+                if(rd != 0){
+                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
+                    X[rd]= (unsigned<XLEN>)res;
+                }
             }
         }
         MULH {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
-	                X[rd]= (unsigned<XLEN>)(res >> XLEN);
-	            }
+                if(rd != 0){
+                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
+                    X[rd]= (unsigned<XLEN>)(res >> XLEN);
+                }
             }
         }
         MULHSU {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	            	signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
-		                X[rd]= (unsigned<XLEN>)(res >> XLEN);
-	            }
+                if(rd != 0){
+                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
+                        X[rd]= (unsigned<XLEN>)(res >> XLEN);
+                }
             }
         }
         MULHU {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                unsigned<MUL_LEN> res = (unsigned<MUL_LEN>)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
-	                X[rd]= (unsigned<XLEN>)(res >> XLEN);
-	            }
+                if(rd != 0){
+                    unsigned<MUL_LEN> res = (unsigned<MUL_LEN>)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
+                    X[rd]= (unsigned<XLEN>)(res >> XLEN);
+                }
             }
         }
         DIV {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                if(X[rs2]!=0){
-	                    unsigned<XLEN> MMIN = 1<<(XLEN-1);
-	                    if(X[rs1]==MMIN && (signed<XLEN>)X[rs2]==-1)
-	                        X[rd] = MMIN;
-	                    else
-	                        X[rd] = (signed<XLEN>)X[rs1] / (signed<XLEN>)X[rs2];
-	                }else 
-	                    X[rd] = -1;
-	            }
+                if(rd != 0){
+                    if(X[rs2]!=0){
+                        unsigned<XLEN> MMIN = 1<<(XLEN-1);
+                        if(X[rs1]==MMIN && (signed<XLEN>)X[rs2]==-1)
+                            X[rd] = MMIN;
+                        else
+                            X[rd] = (signed<XLEN>)X[rs1] / (signed<XLEN>)X[rs2];
+                    }else
+                        X[rd] = -1;
+                }
             }
         }
         DIVU {
@@ -68,7 +68,7 @@ InstructionSet RV32M extends RISCVBase {
             if(rd != 0){
                 if(X[rs2]!=0)
                     X[rd] = X[rs1] / X[rs2];
-                else 
+                else
                     X[rd] = -1;
             }
             }
@@ -77,16 +77,16 @@ InstructionSet RV32M extends RISCVBase {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                if(X[rs2]!=0) {
-	                    unsigned<XLEN> MMIN = 1<<(XLEN-1);
-	                    if(X[rs1]==MMIN && (signed<XLEN>)X[rs2]==-1)
-	                        X[rd] = 0;
-	                    else
-	                        X[rd] = (signed<XLEN>)X[rs1] % (signed<XLEN>)X[rs2];
-	                } else 
-	                    X[rd] = X[rs1];
-	            }
+                if(rd != 0){
+                    if(X[rs2]!=0) {
+                        unsigned<XLEN> MMIN = 1<<(XLEN-1);
+                        if(X[rs1]==MMIN && (signed<XLEN>)X[rs2]==-1)
+                            X[rd] = 0;
+                        else
+                            X[rd] = (signed<XLEN>)X[rs1] % (signed<XLEN>)X[rs2];
+                    } else
+                        X[rd] = X[rs1];
+                }
             }
         }
         REMU {
@@ -96,7 +96,7 @@ InstructionSet RV32M extends RISCVBase {
             if(rd != 0){
                 if(X[rs2]!=0)
                     X[rd] = X[rs1] % X[rs2];
-                else 
+                else
                     X[rd] = X[rs1];
             }
             }
@@ -105,72 +105,71 @@ InstructionSet RV32M extends RISCVBase {
 }
 
 InstructionSet RV64M extends RV32M {
-    instructions{       
+    instructions{
         MULW{
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                X[rd]= (signed<MUL_LEN>)(signed<32>)X[rs1] * (signed<MUL_LEN>)(signed<32>)X[rs2];
-	            }
+                if(rd != 0){
+                    X[rd]= (signed<MUL_LEN>)(signed<32>)X[rs1] * (signed<MUL_LEN>)(signed<32>)X[rs2];
+                }
             }
         }
         DIVW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                if(X[rs2]!=0){
-	                    signed<32> MMIN = 1<<31;
-	                    if((signed<32>)X[rs1]==MMIN && (signed<32>)X[rs2]==-1)
-	                        X[rd] = -1<<31;
-	                    else
-	                        X[rd] = (signed<XLEN>)((signed<32>)X[rs1] / (signed<32>)X[rs2]);
-	                }else 
-	                    X[rd] = -1;
-	            }
+                if(rd != 0){
+                    if(X[rs2]!=0){
+                        signed<32> MMIN = 1<<31;
+                        if((signed<32>)X[rs1]==MMIN && (signed<32>)X[rs2]==-1)
+                            X[rd] = -1<<31;
+                        else
+                            X[rd] = (signed<XLEN>)((signed<32>)X[rs1] / (signed<32>)X[rs2]);
+                    }else
+                        X[rd] = -1;
+                }
             }
         }
         DIVUW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-		            if((unsigned<32>)X[rs2]!=0)
-		                X[rd] = (signed<XLEN>)((unsigned<32>)X[rs1] / (unsigned<32>)X[rs2]);
-		            else 
-		                X[rd] = -1;
-		        }
-	        }
+                if(rd != 0){
+                    if((unsigned<32>)X[rs2]!=0)
+                        X[rd] = (signed<XLEN>)((unsigned<32>)X[rs1] / (unsigned<32>)X[rs2]);
+                    else
+                        X[rd] = -1;
+                }
+            }
         }
         REMW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                if(X[rs2]!=0) {
-	                    signed<32> MMIN = 1<<31;
-	                    if((signed<32>)X[rs1]==MMIN && (signed<32>)X[rs2]==-1)
-	                        X[rd] = 0;
-	                    else
-	                        X[rd] = (signed<XLEN>)((signed<32>)X[rs1] % (signed<32>)X[rs2]);
-	                } else 
-	                    X[rd] = (signed<XLEN>)((signed<32>)X[rs1]);
-	            }
+                if(rd != 0){
+                    if(X[rs2]!=0) {
+                        signed<32> MMIN = 1<<31;
+                        if((signed<32>)X[rs1]==MMIN && (signed<32>)X[rs2]==-1)
+                            X[rd] = 0;
+                        else
+                            X[rd] = (signed<XLEN>)((signed<32>)X[rs1] % (signed<32>)X[rs2]);
+                    } else
+                        X[rd] = (signed<XLEN>)((signed<32>)X[rs1]);
+                }
             }
         }
         REMUW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-		            if((unsigned<32>)X[rs2]!=0)
-		                X[rd] = (signed<XLEN>)((unsigned<32>)X[rs1] % (unsigned<32>)X[rs2]);
-		            else 
-	                    X[rd] = (signed<XLEN>)((signed<32>)X[rs1]);
-        	    }
+                if(rd != 0){
+                    if((unsigned<32>)X[rs2]!=0)
+                        X[rd] = (signed<XLEN>)((unsigned<32>)X[rs1] % (unsigned<32>)X[rs2]);
+                    else
+                        X[rd] = (signed<XLEN>)((signed<32>)X[rs1]);
+                }
             }
         }
     }
 }
-

--- a/RVM.core_desc
+++ b/RVM.core_desc
@@ -6,8 +6,8 @@ InstructionSet RV32M extends RISCVBase {
     }
     instructions{
         MUL{
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
@@ -16,8 +16,8 @@ InstructionSet RV32M extends RISCVBase {
             }
         }
         MULH {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
@@ -26,8 +26,8 @@ InstructionSet RV32M extends RISCVBase {
             }
         }
         MULHSU {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
@@ -36,8 +36,8 @@ InstructionSet RV32M extends RISCVBase {
             }
         }
         MULHU {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     unsigned<MUL_LEN> res = (unsigned<MUL_LEN>)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
@@ -46,8 +46,8 @@ InstructionSet RV32M extends RISCVBase {
             }
         }
         DIV {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     if(X[rs2]!=0){
@@ -62,8 +62,8 @@ InstructionSet RV32M extends RISCVBase {
             }
         }
         DIVU {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
             if(rd != 0){
                 if(X[rs2]!=0)
@@ -74,8 +74,8 @@ InstructionSet RV32M extends RISCVBase {
             }
         }
         REM {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     if(X[rs2]!=0) {
@@ -90,8 +90,8 @@ InstructionSet RV32M extends RISCVBase {
             }
         }
         REMU {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0110011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
             if(rd != 0){
                 if(X[rs2]!=0)
@@ -107,8 +107,8 @@ InstructionSet RV32M extends RISCVBase {
 InstructionSet RV64M extends RV32M {
     instructions{
         MULW{
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0111011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     X[rd]= (signed<MUL_LEN>)(signed<32>)X[rs1] * (signed<MUL_LEN>)(signed<32>)X[rs2];
@@ -116,8 +116,8 @@ InstructionSet RV64M extends RV32M {
             }
         }
         DIVW {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0111011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     if(X[rs2]!=0){
@@ -132,8 +132,8 @@ InstructionSet RV64M extends RV32M {
             }
         }
         DIVUW {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     if((unsigned<32>)X[rs2]!=0)
@@ -144,8 +144,8 @@ InstructionSet RV64M extends RV32M {
             }
         }
         REMW {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0111011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     if(X[rs2]!=0) {
@@ -160,8 +160,8 @@ InstructionSet RV64M extends RV32M {
             }
         }
         REMUW {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0111011;
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if(rd != 0){
                     if((unsigned<32>)X[rs2]!=0)


### PR DESCRIPTION
* Renamed `args_disass` tag to `assembly`.
* Always use Verilog-style literals in encoding.
* `unsigned` (w/o `<width>`) and `int<width>` are no longer valid.

These files are **syntactically** correct as of https://github.com/Minres/CoreDSL/commit/61737d3528188227cc43f041784ee2e5e17d9af5. We'll need to do a second pass over everything once the frontend fully checks the CoreDSL type rules.