### PR TITLE
Fixes and changes from use in ETISS

### DIFF
--- a/RISCVBase.core_desc
+++ b/RISCVBase.core_desc
@@ -1,62 +1,64 @@
 InstructionSet RISCVBase {
     architectural_state {
-        unsigned XLEN;
-        unsigned CSR_SIZE=4096;
-        unsigned INSTR_ALIGNMENT=4;
-        unsigned fence=0;
-        unsigned fencei=1;
-        unsigned fencevmal=2;
-        unsigned fencevmau=3;
-        
+        unsigned int XLEN;
+        unsigned int INSTR_ALIGNMENT = 4;
+
+        unsigned int fence = 0;
+        unsigned int fencei = 1;
+        unsigned int fencevmal = 2;
+        unsigned int fencevmau = 3;
+
         // core registers
-        register unsigned<XLEN>  X[32];
-        register unsigned<XLEN>  PC [[is_pc]];
+        register unsigned<XLEN> X[32] [[is_main_reg]];
+        register unsigned<XLEN> PC [[is_pc]];
+
         // register aliases
         unsigned<XLEN>& ZERO = X[0];
-        unsigned<XLEN>& RA   = X[1];
-        unsigned<XLEN>& SP   = X[2];
-        unsigned<XLEN>& GP   = X[3];
-        unsigned<XLEN>& TP   = X[4];
-        unsigned<XLEN>& T0   = X[5];
-        unsigned<XLEN>& T1   = X[6];
-        unsigned<XLEN>& T2   = X[7];
-        unsigned<XLEN>& S0   = X[8];
-        unsigned<XLEN>& S1   = X[9];
-        unsigned<XLEN>& A0   = X[10];
-        unsigned<XLEN>& A1   = X[11];
-        unsigned<XLEN>& A2   = X[12];
-        unsigned<XLEN>& A3   = X[13];
-        unsigned<XLEN>& A4   = X[14];
-        unsigned<XLEN>& A5   = X[15];
-        unsigned<XLEN>& A6   = X[16];
-        unsigned<XLEN>& A7   = X[17];
-        unsigned<XLEN>& S2   = X[18];
-        unsigned<XLEN>& S3   = X[19];
-        unsigned<XLEN>& S4   = X[20];
-        unsigned<XLEN>& S5   = X[21];
-        unsigned<XLEN>& S6   = X[22];
-        unsigned<XLEN>& S7   = X[23];
-        unsigned<XLEN>& S8   = X[24];
-        unsigned<XLEN>& S9   = X[25];
-        unsigned<XLEN>& S10  = X[26];
-        unsigned<XLEN>& S11  = X[27];
-        unsigned<XLEN>& T3   = X[28];
-        unsigned<XLEN>& T4   = X[29];
-        unsigned<XLEN>& T5   = X[30];
-        unsigned<XLEN>& T6   = X[31];
+        unsigned<XLEN>& RA = X[1];
+        unsigned<XLEN>& SP = X[2];
+        unsigned<XLEN>& GP = X[3];
+        unsigned<XLEN>& TP = X[4];
+        unsigned<XLEN>& T0 = X[5];
+        unsigned<XLEN>& T1 = X[6];
+        unsigned<XLEN>& T2 = X[7];
+        unsigned<XLEN>& S0 = X[8];
+        unsigned<XLEN>& S1 = X[9];
+        unsigned<XLEN>& A0 = X[10];
+        unsigned<XLEN>& A1 = X[11];
+        unsigned<XLEN>& A2 = X[12];
+        unsigned<XLEN>& A3 = X[13];
+        unsigned<XLEN>& A4 = X[14];
+        unsigned<XLEN>& A5 = X[15];
+        unsigned<XLEN>& A6 = X[16];
+        unsigned<XLEN>& A7 = X[17];
+        unsigned<XLEN>& S2 = X[18];
+        unsigned<XLEN>& S3 = X[19];
+        unsigned<XLEN>& S4 = X[20];
+        unsigned<XLEN>& S5 = X[21];
+        unsigned<XLEN>& S6 = X[22];
+        unsigned<XLEN>& S7 = X[23];
+        unsigned<XLEN>& S8 = X[24];
+        unsigned<XLEN>& S9 = X[25];
+        unsigned<XLEN>& S10 = X[26];
+        unsigned<XLEN>& S11 = X[27];
+        unsigned<XLEN>& T3 = X[28];
+        unsigned<XLEN>& T4 = X[29];
+        unsigned<XLEN>& T5 = X[30];
+        unsigned<XLEN>& T6 = X[31];
+
         // address spaces
-        extern char           MEM[1<<XLEN];
-        extern unsigned<XLEN> CSR[1<<CSR_SIZE];
+        extern char MEM[1 << XLEN] [[is_main_mem]];
         extern unsigned<XLEN> FENCE[8];
         extern char RES[8]; // reservation address space
+
         // supplemental state register
-        register unsigned<3>    PRIV=3;
-        register unsigned<XLEN> DPC=0;
+        register unsigned<3> PRIV = 3;
+        register unsigned<XLEN> DPC = 0;
     }
 
     functions {
-    	extern void raise(int irq, int mcause);
-    	extern void leave(int priv_lvl);
-    	extern void wait(int flag);
+        extern void raise(int irq, int mcause);
+        extern void leave(int priv_lvl);
+        extern void wait(int flag);
     }
 }

--- a/RISCVBase.core_desc
+++ b/RISCVBase.core_desc
@@ -2,6 +2,7 @@ InstructionSet RISCVBase {
     architectural_state {
         unsigned int XLEN;
         unsigned int INSTR_ALIGNMENT = 4;
+        unsigned int RFS = 32;
 
         unsigned int fence = 0;
         unsigned int fencei = 1;
@@ -9,7 +10,7 @@ InstructionSet RISCVBase {
         unsigned int fencevmau = 3;
 
         // core registers
-        register unsigned<XLEN> X[32] [[is_main_reg]];
+        register unsigned<XLEN> X[RFS] [[is_main_reg]];
         register unsigned<XLEN> PC [[is_pc]];
 
         // register aliases

--- a/RISCVBase.core_desc
+++ b/RISCVBase.core_desc
@@ -2,6 +2,7 @@ InstructionSet RISCVBase {
     architectural_state {
         unsigned XLEN;
         unsigned CSR_SIZE=4096;
+        unsigned INSTR_ALIGNMENT=4;
         unsigned fence=0;
         unsigned fencei=1;
         unsigned fencevmal=2;

--- a/RISCVBase.core_desc
+++ b/RISCVBase.core_desc
@@ -7,6 +7,7 @@ InstructionSet RISCVBase {
         unsigned fencei=1;
         unsigned fencevmal=2;
         unsigned fencevmau=3;
+        
         // core registers
         register unsigned<XLEN>  X[32];
         register unsigned<XLEN>  PC [[is_pc]];
@@ -49,7 +50,8 @@ InstructionSet RISCVBase {
         extern unsigned<XLEN> FENCE[8];
         extern char RES[8]; // reservation address space
         // supplemental state register
-        register unsigned<2>    PRIV;
+        register unsigned<3>    PRIV=3;
+        register unsigned<XLEN> DPC=0;
     }
 
     functions {

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -78,7 +78,7 @@ InstructionSet RV32I extends RISCVBase {
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
-                signed<16> res = (signed<16>)MEM[X[rs1] + (signed<12>)imm];
+                signed<16> res = (signed<16>)MEM[load_address];
                 if(rd!=0) X[rd]=res;
              }    
         }
@@ -87,7 +87,7 @@ InstructionSet RV32I extends RISCVBase {
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
-                signed<32> res = (signed<32>)MEM[X[rs1] + (signed<12>)imm];
+                signed<32> res = (signed<32>)MEM[load_address];
                 if(rd!=0) X[rd]=(unsigned<32>)res;
             } 
         }
@@ -104,7 +104,7 @@ InstructionSet RV32I extends RISCVBase {
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
-                unsigned<16> res = (unsigned<16>)MEM[X[rs1] + (signed<12>)imm];
+                unsigned<16> res = (unsigned<16>)MEM[load_address];
                 if(rd!=0) X[rd]=res;
             }
         }

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -29,7 +29,7 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1100111;
             args_disass: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
-	            signed<XLEN> new_pc = X[rs1] + (signed<12>)imm;
+	            signed<XLEN> new_pc = (X[rs1] + (signed<12>)imm) & ~1;
                 if(new_pc % INSTR_ALIGNMENT) {
 	                raise(0, 0);
 	            } else {

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -3,19 +3,19 @@ import "RISCVBase.core_desc"
 InstructionSet RV32I extends RISCVBase {
     instructions {
         LUI {
-            encoding: imm[31:12] :: rd[4:0] :: 0b0110111;
+            encoding: imm[31:12] :: rd[4:0] :: 7'b0110111;
             assembly: "{name(rd)}, {imm:#05x}";
             behavior: if (rd != 0) X[rd] = (signed<XLEN>)imm;
         }
 
         AUIPC {
-            encoding: imm[31:12] :: rd[4:0] :: 0b0010111;
+            encoding: imm[31:12] :: rd[4:0] :: 7'b0010111;
             assembly: "{name(rd)}, {imm:#08x}";
             behavior: if (rd != 0) X[rd] = PC+(signed<XLEN>)imm;
         }
 
         JAL [[no_cont]] {
-            encoding: imm[20:20] :: imm[10:1] :: imm[11:11] :: imm[19:12] :: rd[4:0] :: 0b1101111;
+            encoding: imm[20:20] :: imm[10:1] :: imm[11:11] :: imm[19:12] :: rd[4:0] :: 7'b1101111;
             assembly: "{name(rd)}, {imm:#0x}";
             behavior: {
                 if (imm % INSTR_ALIGNMENT) {
@@ -28,7 +28,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         JALR [[no_cont]] {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1100111;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1100111;
             assembly: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
                 unsigned<XLEN> new_pc = (X[rs1] + (signed<12>)imm) & ~0x1;
@@ -42,7 +42,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         BEQ [[no_cont]] [[cond]] {
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b000 :: imm[4:1] :: imm[11:11] :: 0b1100011;
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if (X[rs1] == X[rs2]) {
@@ -56,7 +56,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         BNE [[no_cont]] [[cond]] {
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b001 :: imm[4:1] :: imm[11:11] :: 0b1100011;
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if (X[rs1] != X[rs2]) {
@@ -70,7 +70,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         BLT [[no_cont]] [[cond]] {
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b100 :: imm[4:1] :: imm[11:11] :: 0b1100011;
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if ((signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2]) {
@@ -84,7 +84,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         BGE [[no_cont]] [[cond]] {
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b101 :: imm[4:1] :: imm[11:11] :: 0b1100011;
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if ((signed<XLEN>)X[rs1] >= (signed<XLEN>)X[rs2]) {
@@ -98,7 +98,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         BLTU [[no_cont]] [[cond]] {
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b110 :: imm[4:1] :: imm[11:11] :: 0b1100011;
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if (X[rs1] < X[rs2]) {
@@ -112,7 +112,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         BGEU [[no_cont]] [[cond]] {
-            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b111 :: imm[4:1] :: imm[11:11] :: 0b1100011;
+            encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if (X[rs1] >= X[rs2]) {
@@ -126,7 +126,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         LB {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0000011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
@@ -136,7 +136,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         LH {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0000011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
@@ -146,7 +146,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         LW {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0000011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
@@ -156,7 +156,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         LBU {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0000011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
@@ -166,7 +166,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         LHU {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0000011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
@@ -176,7 +176,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         SB {
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b000 :: imm[4:0] :: 0b0100011;
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: imm[4:0] :: 7'b0100011;
             assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
@@ -185,7 +185,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         SH {
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b001 :: imm[4:0] :: 0b0100011;
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: imm[4:0] :: 7'b0100011;
             assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
@@ -194,7 +194,7 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         SW {
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: imm[4:0] :: 0b0100011;
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: imm[4:0] :: 7'b0100011;
             assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
@@ -203,157 +203,157 @@ InstructionSet RV32I extends RISCVBase {
         }
 
         ADDI {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0010011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = X[rs1] + (signed<12>)imm;
         }
 
         SLTI {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0010011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = ((signed<XLEN>)X[rs1] < (signed<12>)imm) ? 1 : 0;
         }
 
         SLTIU {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0010011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = (X[rs1] < (unsigned<XLEN>)((signed<12>)imm)) ? 1 : 0;
         }
 
         XORI {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0010011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = X[rs1] ^ (signed<12>)imm;
         }
 
         ORI {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0010011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = X[rs1] | (signed<12>)imm;
         }
 
         ANDI {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0010011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = X[rs1] & (signed<12>)imm;
         }
 
         SLLI {
-            encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0010011;
+            encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = X[rs1] << shamt;
         }
 
         SRLI {
-            encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
+            encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = X[rs1] >> shamt;
         }
 
         SRAI {
-            encoding: 0b0100000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
+            encoding: 7'b0100000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> shamt;
         }
 
         ADD {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] + X[rs2];
         }
 
         SUB {
-            encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] - X[rs2];
         }
 
         SLL {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] << (X[rs2] & (XLEN - 1));
         }
 
         SLT {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2] ? 1 : 0;
         }
 
         SLTU {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
                behavior: if (rd != 0) X[rd] = (unsigned<XLEN>)X[rs1] < (unsigned<XLEN>)X[rs2] ? 1 : 0;
         }
 
         XOR {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] ^ X[rs2];
         }
 
         SRL {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] >> (X[rs2] & (XLEN - 1));
         }
 
         SRA {
-            encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> (X[rs2] & (XLEN - 1));
         }
 
         OR {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] | X[rs2];
         }
 
         AND {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] & X[rs2];
         }
 
         FENCE {
-            encoding: fm[3:0] :: pred[3:0] :: succ[3:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0001111;
+            encoding: fm[3:0] :: pred[3:0] :: succ[3:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0001111;
             assembly:"{pred}, {succ} ({fm} , {name(rs1)}, {name(rd)})";
             behavior: FENCE[fence] = pred << 4 | succ;
         }
 
         ECALL [[no_cont]] {
-            encoding: 0b000000000000 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 0b000000000000 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: raise(0, 11);
         }
 
         EBREAK [[no_cont]] {
-            encoding: 0b000000000001 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 0b000000000001 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: raise(0, 3);
         }
 
         URET [[no_cont]] {
-            encoding: 0b0000000 :: 0b00010 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 7'b0000000 :: 5'b00010 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: leave(0);
         }
 
         SRET [[no_cont]] {
-            encoding: 0b0001000 :: 0b00010 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 7'b0001000 :: 5'b00010 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: leave(1);
         }
 
         MRET [[no_cont]] {
-            encoding: 0b0011000 :: 0b00010 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 7'b0011000 :: 5'b00010 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: leave(3);
         }
 
         WFI {
-            encoding: 0b0001000 :: 0b00101 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
+            encoding: 7'b0001000 :: 5'b00101 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
             behavior: wait(1);
         }
 
         DRET {
-            encoding: 0b01111011001000000000000001110011;
+            encoding: 32'b01111011001000000000000001110011;
             behavior: {
                 if (PRIV < 4)
                     raise(0, 2);
@@ -374,7 +374,7 @@ InstructionSet Zicsr extends RISCVBase {
 
     instructions {
         CSRRW {
-            encoding: csr[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1110011;
+            encoding: csr[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1110011;
             assembly:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
                 unsigned<XLEN> xrs1 = X[rs1];
@@ -390,7 +390,7 @@ InstructionSet Zicsr extends RISCVBase {
         }
 
         CSRRS {
-            encoding: csr[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1110011;
+            encoding: csr[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1110011;
             assembly:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
@@ -401,7 +401,7 @@ InstructionSet Zicsr extends RISCVBase {
         }
 
         CSRRC {
-            encoding: csr[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b1110011;
+            encoding: csr[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b1110011;
             assembly:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
@@ -412,7 +412,7 @@ InstructionSet Zicsr extends RISCVBase {
         }
 
         CSRRWI {
-            encoding: csr[11:0] :: zimm[4:0] :: 0b101 :: rd[4:0] :: 0b1110011;
+            encoding: csr[11:0] :: zimm[4:0] :: 3'b101 :: rd[4:0] :: 7'b1110011;
             assembly:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
@@ -422,7 +422,7 @@ InstructionSet Zicsr extends RISCVBase {
         }
 
         CSRRSI {
-            encoding: csr[11:0] :: zimm[4:0] :: 0b110 :: rd[4:0] :: 0b1110011;
+            encoding: csr[11:0] :: zimm[4:0] :: 3'b110 :: rd[4:0] :: 7'b1110011;
             assembly:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
@@ -432,7 +432,7 @@ InstructionSet Zicsr extends RISCVBase {
         }
 
         CSRRCI {
-            encoding: csr[11:0] :: zimm[4:0] :: 0b111 :: rd[4:0] :: 0b1110011;
+            encoding: csr[11:0] :: zimm[4:0] :: 3'b111 :: rd[4:0] :: 7'b1110011;
             assembly:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
@@ -446,7 +446,7 @@ InstructionSet Zicsr extends RISCVBase {
 InstructionSet Zifencei extends RISCVBase {
     instructions {
         FENCE_I [[flush]] {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0001111 ;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0001111 ;
             assembly:"{name(rs1)}, {name(rd)}, {imm}";
             behavior: FENCE[fencei] = imm;
         }

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -241,31 +241,19 @@ InstructionSet RV32I extends RISCVBase {
         SLLI {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if (shamt > 31) {
-                raise(0,0);
-            } else {
-                if (rd != 0) X[rd] = X[rs1] << shamt;
-            }
+            behavior: if (rd != 0) X[rd] = X[rs1] << shamt;
         }
 
         SRLI {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if (shamt > 31) {
-                raise(0,0);
-            } else {
-                if (rd != 0) X[rd] = X[rs1] >> shamt;
-            }
+            behavior: if (rd != 0) X[rd] = X[rs1] >> shamt;
         }
 
         SRAI {
             encoding: 0b0100000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if (shamt > 31) {
-                raise(0,0);
-            } else {
-                if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> shamt;
-            }
+            behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> shamt;
         }
 
         ADD {

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -31,7 +31,7 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1100111;
             args_disass: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
-                signed<XLEN> new_pc = (X[rs1] + (signed<12>)imm) & ~1;
+                unsigned<XLEN> new_pc = (X[rs1] + (signed<12>)imm) & ~0x1;
                 if (new_pc % INSTR_ALIGNMENT) {
                     raise(0, 0);
                 } else {

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -306,6 +306,11 @@ InstructionSet RV32I extends RISCVBase {
             encoding: 0b0001000 :: 0b00101 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
             behavior: wait(1);
         }
+    }
+}
+
+InstructionSet Zicsr extends RISCVBase {
+    instructions {
         CSRRW {
             encoding: csr[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {name(rs1)}";
@@ -378,16 +383,7 @@ InstructionSet Zifencei extends RISCVBase {
             args_disass:"{name(rs1)}, {name(rd)}, {imm}";
             behavior: FENCE[fencei] = imm;
         }
-        SFENCE_VMA {
-            encoding: 0b0001001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: 0b00000 :: 0b1110011;
-            args_disass:"{name(rs2)}, {rs1}";
-            behavior: {
-                FENCE[fencevmal] = (unsigned)rs1;
-            FENCE[fencevmau] = (unsigned)rs2;
-            }
-        }
-     }
-     
+     }     
  }
      
 

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -131,7 +131,7 @@ InstructionSet RV32I extends RISCVBase {
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<8> res = (signed<8>)MEM[load_address];
-                if(rd != 0) X[rd] = res;
+                if(rd != 0) X[rd] = (signed<XLEN>)res;
             }
         }
 
@@ -141,7 +141,7 @@ InstructionSet RV32I extends RISCVBase {
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<16> res = (signed<16>)MEM[load_address];
-                if (rd != 0) X[rd] = res;
+                if (rd != 0) X[rd] = (signed<XLEN>)res;
              }
         }
 
@@ -151,7 +151,7 @@ InstructionSet RV32I extends RISCVBase {
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<32> res = (signed<32>)MEM[load_address];
-                if (rd != 0) X[rd] = (unsigned<32>)res;
+                if (rd != 0) X[rd] = (signed<XLEN>)res;
             }
         }
 
@@ -161,7 +161,7 @@ InstructionSet RV32I extends RISCVBase {
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 unsigned<8> res = (unsigned<8>)MEM[load_address];
-                if (rd != 0) X[rd] = res;
+                if (rd != 0) X[rd] = (unsigned<XLEN>)res;
             }
         }
 
@@ -171,7 +171,7 @@ InstructionSet RV32I extends RISCVBase {
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 unsigned<16> res = (unsigned<16>)MEM[load_address];
-                if(rd != 0) X[rd] = res;
+                if(rd != 0) X[rd] = (unsigned<XLEN>)res;
             }
         }
 
@@ -198,7 +198,7 @@ InstructionSet RV32I extends RISCVBase {
             args_disass:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
-                MEM[store_address] = X[rs2];
+                MEM[store_address] = (signed<32>)X[rs2];
             }
         }
 

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -1,167 +1,198 @@
 import "RISCVBase.core_desc"
 
 InstructionSet RV32I extends RISCVBase {
-     
-    instructions { 
-        LUI{
+    instructions {
+        LUI {
             encoding: imm[31:12] :: rd[4:0] :: 0b0110111;
             args_disass: "{name(rd)}, {imm:#05x}";
-            behavior: if(rd!=0) X[rd] = (signed<XLEN>)imm;
+            behavior: if (rd != 0) X[rd] = (signed<XLEN>)imm;
         }
-        AUIPC{
+
+        AUIPC {
             encoding: imm[31:12] :: rd[4:0] :: 0b0010111;
             args_disass: "{name(rd)}, {imm:#08x}";
-            behavior: if(rd!=0) X[rd] = PC+(signed<XLEN>)imm;
+            behavior: if (rd != 0) X[rd] = PC+(signed<XLEN>)imm;
         }
-        JAL[[no_cont]]{
+
+        JAL [[no_cont]] {
             encoding: imm[20:20] :: imm[10:1] :: imm[11:11] :: imm[19:12] :: rd[4:0] :: 0b1101111;
             args_disass: "{name(rd)}, {imm:#0x}";
             behavior: {
-                if(imm % INSTR_ALIGNMENT) {
+                if (imm % INSTR_ALIGNMENT) {
                     raise(0, 0);
                 } else {
-                    if(rd!=0) X[rd] = PC+4;
-                    PC=PC+(signed<21>)imm;
+                    if (rd != 0) X[rd] = PC+4;
+                    PC = PC + (signed<21>)imm;
                 }
-        	}
+            }
         }
-        JALR[[no_cont]]{
+
+        JALR [[no_cont]] {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1100111;
             args_disass: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
-	            signed<XLEN> new_pc = (X[rs1] + (signed<12>)imm) & ~1;
-                if(new_pc % INSTR_ALIGNMENT) {
-	                raise(0, 0);
-	            } else {
-	                if(rd!=0) X[rd] = PC+4;
-	                PC=new_pc & ~0x1;
-	            }	            
+                signed<XLEN> new_pc = (X[rs1] + (signed<12>)imm) & ~1;
+                if (new_pc % INSTR_ALIGNMENT) {
+                    raise(0, 0);
+                } else {
+                    if (rd != 0) X[rd] = PC+4;
+                    PC = new_pc & ~0x1;
+                }
             }
         }
-        BEQ[[no_cont]] [[cond]]{
+
+        BEQ [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b000 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if(X[rs1]==X[rs2])
+                if (X[rs1] == X[rs2]) {
                     if(imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
-                    } else 
+                    } else {
                         PC = PC + (signed<13>)imm;
-                
+                    }
+                }
             }
         }
-        BNE[[no_cont]] [[cond]]{
+
+        BNE [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b001 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if(X[rs1]!=X[rs2])
-                    if(imm % INSTR_ALIGNMENT) {
+                if (X[rs1] != X[rs2]) {
+                    if (imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
-                    } else 
+                    } else {
                         PC = PC + (signed<13>)imm;
-
+                    }
+                }
             }
         }
-        BLT[[no_cont]] [[cond]]{
+
+        BLT [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b100 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if((signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2])
-                    if(imm % INSTR_ALIGNMENT) {
+                if ((signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2]) {
+                    if (imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
-                    } else 
+                    } else {
                         PC = PC + (signed<13>)imm;
+                    }
+                }
             }
         }
-        BGE[[no_cont]] [[cond]] {
+
+        BGE [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b101 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if((signed<XLEN>)X[rs1] >= (signed<XLEN>)X[rs2])
-                    if(imm % INSTR_ALIGNMENT) {
+                if ((signed<XLEN>)X[rs1] >= (signed<XLEN>)X[rs2]) {
+                    if (imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
-                    } else 
+                    } else {
                         PC = PC + (signed<13>)imm;
+                    }
+                }
             }
         }
-        BLTU[[no_cont]] [[cond]] {
+
+        BLTU [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b110 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if(X[rs1]<X[rs2])
-                    if(imm % INSTR_ALIGNMENT) {
+                if (X[rs1] < X[rs2]) {
+                    if (imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
-                    } else 
+                    } else {
                         PC = PC + (signed<13>)imm;
+                    }
+                }
             }
         }
-        BGEU[[no_cont]] [[cond]] {
+
+        BGEU [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b111 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if(X[rs1]>=X[rs2])
-                    if(imm % INSTR_ALIGNMENT) {
+                if (X[rs1] >= X[rs2]) {
+                    if (imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
-                    } else 
+                    } else {
                         PC = PC + (signed<13>)imm;
+                    }
+                }
             }
         }
+
         LB {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0000011;
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-                signed<8> res = (signed<8>)MEM[X[rs1] + (signed<12>)imm];
-                if(rd!=0) X[rd]=res;
+                unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
+                signed<8> res = (signed<8>)MEM[load_address];
+                if(rd != 0) X[rd] = res;
             }
         }
+
         LH {
             encoding: imm[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0000011;
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<16> res = (signed<16>)MEM[load_address];
-                if(rd!=0) X[rd]=res;
-             }    
+                if (rd != 0) X[rd] = res;
+             }
         }
+
         LW {
             encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0000011;
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<32> res = (signed<32>)MEM[load_address];
-                if(rd!=0) X[rd]=(unsigned<32>)res;
-            } 
+                if (rd != 0) X[rd] = (unsigned<32>)res;
+            }
         }
+
         LBU {
             encoding: imm[11:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0000011;
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<8> res = (unsigned<8>)MEM[X[rs1] + (signed<12>)imm];
-                if(rd!=0) X[rd]=res;
+                unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
+                unsigned<8> res = (unsigned<8>)MEM[load_address];
+                if (rd != 0) X[rd] = res;
             }
         }
+
         LHU {
             encoding: imm[11:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0000011;
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 unsigned<16> res = (unsigned<16>)MEM[load_address];
-                if(rd!=0) X[rd]=res;
+                if(rd != 0) X[rd] = res;
             }
         }
+
         SB {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b000 :: imm[4:0] :: 0b0100011;
             args_disass:"{name(rs2)}, {imm}({name(rs1)})";
-            behavior: MEM[X[rs1] + (signed<12>)imm] = (char)X[rs2];
+            behavior: {
+                unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
+                MEM[store_address] = (signed<8>)X[rs2];
+            }
         }
+
         SH {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b001 :: imm[4:0] :: 0b0100011;
             args_disass:"{name(rs2)}, {imm}({name(rs1)})";
-            behavior: { 
+            behavior: {
                 unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
-                MEM[store_address] = (short)X[rs2];
+                MEM[store_address] = (signed<16>)X[rs2];
             }
         }
+
         SW {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: imm[4:0] :: 0b0100011;
             args_disass:"{name(rs2)}, {imm}({name(rs1)})";
@@ -170,142 +201,169 @@ InstructionSet RV32I extends RISCVBase {
                 MEM[store_address] = X[rs2];
             }
         }
+
         ADDI {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if(rd != 0) X[rd] = X[rs1] + (signed<12>)imm;
+            behavior: if (rd != 0) X[rd] = X[rs1] + (signed<12>)imm;
         }
+
         SLTI {
             encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] < (signed<12>)imm? 1 : 0;
         }
+
         SLTIU {
             encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = (X[rs1] < (unsigned<XLEN>)((signed<12>)imm))? 1 : 0;
         }
+
         XORI {
             encoding: imm[11:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if(rd != 0) X[rd] = X[rs1] ^ (signed<12>)imm;
+            behavior: if (rd != 0) X[rd] = X[rs1] ^ (signed<12>)imm;
         }
+
         ORI {
             encoding: imm[11:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if(rd != 0) X[rd] = X[rs1] | (signed<12>)imm;
+            behavior: if (rd != 0) X[rd] = X[rs1] | (signed<12>)imm;
         }
+
         ANDI {
             encoding: imm[11:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if(rd != 0) X[rd] = X[rs1] & (signed<12>)imm;
+            behavior: if (rd != 0) X[rd] = X[rs1] & (signed<12>)imm;
         }
+
         SLLI {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if(shamt > 31){
+            behavior: if (shamt > 31) {
                 raise(0,0);
             } else {
-                if(rd != 0) X[rd] = X[rs1] << shamt;
+                if (rd != 0) X[rd] = X[rs1] << shamt;
             }
         }
+
         SRLI {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if(shamt > 31){
+            behavior: if (shamt > 31) {
                 raise(0,0);
             } else {
-                if(rd != 0) X[rd] = X[rs1] >> shamt;
+                if (rd != 0) X[rd] = X[rs1] >> shamt;
             }
         }
+
         SRAI {
             encoding: 0b0100000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if(shamt > 31){
+            behavior: if (shamt > 31) {
                 raise(0,0);
             } else {
-                if(rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> shamt;
+                if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> shamt;
             }
         }
+
         ADD {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if(rd != 0) X[rd] = X[rs1] + X[rs2];
+            behavior: if (rd != 0) X[rd] = X[rs1] + X[rs2];
         }
+
         SUB {
             encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if(rd != 0) X[rd] = X[rs1] - X[rs2];
+            behavior: if (rd != 0) X[rd] = X[rs1] - X[rs2];
         }
+
         SLL {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if(rd != 0) X[rd] = X[rs1]<< (X[rs2]&(XLEN-1));
+            behavior: if (rd != 0) X[rd] = X[rs1] << (X[rs2] & (XLEN - 1));
         }
+
         SLT {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2]? 1 : 0;
+            behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2] ? 1 : 0;
         }
+
         SLTU {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-           	behavior: if (rd != 0) X[rd] = (unsigned<XLEN>)X[rs1] < (unsigned<XLEN>)X[rs2]? 1 : 0;
+               behavior: if (rd != 0) X[rd] = (unsigned<XLEN>)X[rs1] < (unsigned<XLEN>)X[rs2] ? 1 : 0;
         }
+
         XOR {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if(rd != 0) X[rd] = X[rs1] ^ X[rs2];
+            behavior: if (rd != 0) X[rd] = X[rs1] ^ X[rs2];
         }
+
         SRL {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if(rd != 0) X[rd] = X[rs1] >> (X[rs2]&(XLEN-1));
+            behavior: if (rd != 0) X[rd] = X[rs1] >> (X[rs2] & (XLEN - 1));
         }
+
         SRA {
             encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if(rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> (X[rs2]&(XLEN-1));
+            behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> (X[rs2] & (XLEN - 1));
         }
+
         OR {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if(rd != 0) X[rd] = X[rs1] | X[rs2];
+            behavior: if (rd != 0) X[rd] = X[rs1] | X[rs2];
         }
+
         AND {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if(rd != 0) X[rd] = X[rs1] & X[rs2];
+            behavior: if (rd != 0) X[rd] = X[rs1] & X[rs2];
         }
+
         FENCE {
             encoding: fm[3:0] :: pred[3:0] :: succ[3:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0001111;
             args_disass:"{pred}, {succ} ({fm} , {name(rs1)}, {name(rd)})";
-            behavior: FENCE[fence] = pred<<4 | succ;
+            behavior: FENCE[fence] = pred << 4 | succ;
         }
-        ECALL[[no_cont]] {
+
+        ECALL [[no_cont]] {
             encoding: 0b000000000000 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
             behavior: raise(0, 11);
         }
-        EBREAK[[no_cont]] {
+
+        EBREAK [[no_cont]] {
             encoding: 0b000000000001 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
             behavior: raise(0, 3);
         }
-        URET[[no_cont]] {
+
+        URET [[no_cont]] {
             encoding: 0b0000000 :: 0b00010 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
             behavior: leave(0);
         }
-        SRET[[no_cont]]  {
+
+        SRET [[no_cont]] {
             encoding: 0b0001000 :: 0b00010 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
             behavior: leave(1);
         }
-        MRET[[no_cont]] {
+
+        MRET [[no_cont]] {
             encoding: 0b0011000 :: 0b00010 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
             behavior: leave(3);
         }
-        WFI  {
+
+        WFI {
             encoding: 0b0001000 :: 0b00101 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
             behavior: wait(1);
         }
+
         DRET {
             encoding: 0b01111011001000000000000001110011;
             behavior: {
@@ -313,7 +371,7 @@ InstructionSet RV32I extends RISCVBase {
                     raise(0, 2);
                 else {
                     PC=DPC;
-                    PRIV &= 0x3;                    
+                    PRIV &= 0x3;
                 }
             }
         }
@@ -321,80 +379,88 @@ InstructionSet RV32I extends RISCVBase {
 }
 
 InstructionSet Zicsr extends RISCVBase {
+    architectural_state {
+        unsigned int CSR_SIZE = 4096;
+        extern unsigned<XLEN> CSR[CSR_SIZE];
+    }
+
     instructions {
         CSRRW {
             encoding: csr[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
-	            unsigned<XLEN> xrs1 = X[rs1];
-	            if(rd!=0){
-	                unsigned<XLEN> xrd = CSR[csr];
-	                CSR[csr] = xrs1; 
-	                // make sure Xrd is updated once CSR write succeeds
-	                X[rd] = xrd;
-	            } else {
-	                CSR[csr] = xrs1;
-	            }
+                unsigned<XLEN> xrs1 = X[rs1];
+                if (rd != 0) {
+                    unsigned<XLEN> xrd = CSR[csr];
+                    CSR[csr] = xrs1;
+                    // make sure Xrd is updated once CSR write succeeds
+                    X[rd] = xrd;
+                } else {
+                    CSR[csr] = xrs1;
+                }
             }
         }
+
         CSRRS {
             encoding: csr[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
-	            unsigned<XLEN> xrd = CSR[csr];
-	            unsigned<XLEN> xrs1 = X[rs1];
-                if(rs1!=0) CSR[csr] = xrd | xrs1;    
-	            if(rd!=0) X[rd] = xrd;
+                unsigned<XLEN> xrd = CSR[csr];
+                unsigned<XLEN> xrs1 = X[rs1];
+                if (rs1 != 0) CSR[csr] = xrd | xrs1;
+                if (rd != 0) X[rd] = xrd;
             }
         }
+
         CSRRC {
             encoding: csr[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
-	            unsigned<XLEN> xrd = CSR[csr];
-	            unsigned<XLEN> xrs1 = X[rs1];
-                if(rs1!=0) CSR[csr] = xrd & ~xrs1;
-	            if(rd!=0) X[rd] = xrd;
+                unsigned<XLEN> xrd = CSR[csr];
+                unsigned<XLEN> xrs1 = X[rs1];
+                if (rs1 != 0) CSR[csr] = xrd & ~xrs1;
+                if (rd != 0) X[rd] = xrd;
             }
         }
+
         CSRRWI {
             encoding: csr[11:0] :: zimm[4:0] :: 0b101 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
-	            CSR[csr] = (unsigned<XLEN>)zimm;    
-                if(rd!=0) X[rd] = xrd;
+                CSR[csr] = (unsigned<XLEN>)zimm;
+                if (rd != 0) X[rd] = xrd;
             }
         }
+
         CSRRSI {
             encoding: csr[11:0] :: zimm[4:0] :: 0b110 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
-	            unsigned<XLEN> xrd = CSR[csr];
-	            if(zimm!=0) CSR[csr] = xrd | (unsigned<XLEN>)zimm;
-	            if(rd!=0) X[rd] = xrd;
+                unsigned<XLEN> xrd = CSR[csr];
+                if (zimm != 0) CSR[csr] = xrd | (unsigned<XLEN>)zimm;
+                if (rd != 0) X[rd] = xrd;
             }
         }
+
         CSRRCI {
             encoding: csr[11:0] :: zimm[4:0] :: 0b111 :: rd[4:0] :: 0b1110011;
             args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
-	            unsigned<XLEN> xrd = CSR[csr];
-                if(zimm!=0) CSR[csr] = xrd & ~((unsigned<XLEN>)zimm);    
-	            if(rd!=0) X[rd] = xrd;
+                unsigned<XLEN> xrd = CSR[csr];
+                if (zimm != 0) CSR[csr] = xrd & ~((unsigned<XLEN>)zimm);
+                if (rd != 0) X[rd] = xrd;
             }
-        }   
+        }
     }
 }
 
 InstructionSet Zifencei extends RISCVBase {
     instructions {
-        FENCE_I[[flush]] {
+        FENCE_I [[flush]] {
             encoding: imm[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0001111 ;
             args_disass:"{name(rs1)}, {name(rd)}, {imm}";
             behavior: FENCE[fencei] = imm;
         }
-     }     
+     }
  }
-     
-

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -4,19 +4,19 @@ InstructionSet RV32I extends RISCVBase {
     instructions {
         LUI {
             encoding: imm[31:12] :: rd[4:0] :: 0b0110111;
-            args_disass: "{name(rd)}, {imm:#05x}";
+            assembly: "{name(rd)}, {imm:#05x}";
             behavior: if (rd != 0) X[rd] = (signed<XLEN>)imm;
         }
 
         AUIPC {
             encoding: imm[31:12] :: rd[4:0] :: 0b0010111;
-            args_disass: "{name(rd)}, {imm:#08x}";
+            assembly: "{name(rd)}, {imm:#08x}";
             behavior: if (rd != 0) X[rd] = PC+(signed<XLEN>)imm;
         }
 
         JAL [[no_cont]] {
             encoding: imm[20:20] :: imm[10:1] :: imm[11:11] :: imm[19:12] :: rd[4:0] :: 0b1101111;
-            args_disass: "{name(rd)}, {imm:#0x}";
+            assembly: "{name(rd)}, {imm:#0x}";
             behavior: {
                 if (imm % INSTR_ALIGNMENT) {
                     raise(0, 0);
@@ -29,7 +29,7 @@ InstructionSet RV32I extends RISCVBase {
 
         JALR [[no_cont]] {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1100111;
-            args_disass: "{name(rd)}, {name(rs1)}, {imm:#0x}";
+            assembly: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
                 unsigned<XLEN> new_pc = (X[rs1] + (signed<12>)imm) & ~0x1;
                 if (new_pc % INSTR_ALIGNMENT) {
@@ -43,7 +43,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BEQ [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b000 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if (X[rs1] == X[rs2]) {
                     if(imm % INSTR_ALIGNMENT) {
@@ -57,7 +57,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BNE [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b001 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if (X[rs1] != X[rs2]) {
                     if (imm % INSTR_ALIGNMENT) {
@@ -71,7 +71,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BLT [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b100 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if ((signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2]) {
                     if (imm % INSTR_ALIGNMENT) {
@@ -85,7 +85,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BGE [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b101 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if ((signed<XLEN>)X[rs1] >= (signed<XLEN>)X[rs2]) {
                     if (imm % INSTR_ALIGNMENT) {
@@ -99,7 +99,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BLTU [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b110 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if (X[rs1] < X[rs2]) {
                     if (imm % INSTR_ALIGNMENT) {
@@ -113,7 +113,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BGEU [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b111 :: imm[4:1] :: imm[11:11] :: 0b1100011;
-            args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
                 if (X[rs1] >= X[rs2]) {
                     if (imm % INSTR_ALIGNMENT) {
@@ -127,7 +127,7 @@ InstructionSet RV32I extends RISCVBase {
 
         LB {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<8> res = (signed<8>)MEM[load_address];
@@ -137,7 +137,7 @@ InstructionSet RV32I extends RISCVBase {
 
         LH {
             encoding: imm[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<16> res = (signed<16>)MEM[load_address];
@@ -147,7 +147,7 @@ InstructionSet RV32I extends RISCVBase {
 
         LW {
             encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<32> res = (signed<32>)MEM[load_address];
@@ -157,7 +157,7 @@ InstructionSet RV32I extends RISCVBase {
 
         LBU {
             encoding: imm[11:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 unsigned<8> res = (unsigned<8>)MEM[load_address];
@@ -167,7 +167,7 @@ InstructionSet RV32I extends RISCVBase {
 
         LHU {
             encoding: imm[11:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 unsigned<16> res = (unsigned<16>)MEM[load_address];
@@ -177,7 +177,7 @@ InstructionSet RV32I extends RISCVBase {
 
         SB {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b000 :: imm[4:0] :: 0b0100011;
-            args_disass:"{name(rs2)}, {imm}({name(rs1)})";
+            assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
                 MEM[store_address] = (signed<8>)X[rs2];
@@ -186,7 +186,7 @@ InstructionSet RV32I extends RISCVBase {
 
         SH {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b001 :: imm[4:0] :: 0b0100011;
-            args_disass:"{name(rs2)}, {imm}({name(rs1)})";
+            assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
                 MEM[store_address] = (signed<16>)X[rs2];
@@ -195,7 +195,7 @@ InstructionSet RV32I extends RISCVBase {
 
         SW {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: imm[4:0] :: 0b0100011;
-            args_disass:"{name(rs2)}, {imm}({name(rs1)})";
+            assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
                 MEM[store_address] = (signed<32>)X[rs2];
@@ -204,121 +204,121 @@ InstructionSet RV32I extends RISCVBase {
 
         ADDI {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = X[rs1] + (signed<12>)imm;
         }
 
         SLTI {
             encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = ((signed<XLEN>)X[rs1] < (signed<12>)imm) ? 1 : 0;
         }
 
         SLTIU {
             encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = (X[rs1] < (unsigned<XLEN>)((signed<12>)imm)) ? 1 : 0;
         }
 
         XORI {
             encoding: imm[11:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = X[rs1] ^ (signed<12>)imm;
         }
 
         ORI {
             encoding: imm[11:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = X[rs1] | (signed<12>)imm;
         }
 
         ANDI {
             encoding: imm[11:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: if (rd != 0) X[rd] = X[rs1] & (signed<12>)imm;
         }
 
         SLLI {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = X[rs1] << shamt;
         }
 
         SRLI {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = X[rs1] >> shamt;
         }
 
         SRAI {
             encoding: 0b0100000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> shamt;
         }
 
         ADD {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] + X[rs2];
         }
 
         SUB {
             encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] - X[rs2];
         }
 
         SLL {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] << (X[rs2] & (XLEN - 1));
         }
 
         SLT {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2] ? 1 : 0;
         }
 
         SLTU {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
                behavior: if (rd != 0) X[rd] = (unsigned<XLEN>)X[rs1] < (unsigned<XLEN>)X[rs2] ? 1 : 0;
         }
 
         XOR {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] ^ X[rs2];
         }
 
         SRL {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] >> (X[rs2] & (XLEN - 1));
         }
 
         SRA {
             encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> (X[rs2] & (XLEN - 1));
         }
 
         OR {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] | X[rs2];
         }
 
         AND {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs1] & X[rs2];
         }
 
         FENCE {
             encoding: fm[3:0] :: pred[3:0] :: succ[3:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0001111;
-            args_disass:"{pred}, {succ} ({fm} , {name(rs1)}, {name(rd)})";
+            assembly:"{pred}, {succ} ({fm} , {name(rs1)}, {name(rd)})";
             behavior: FENCE[fence] = pred << 4 | succ;
         }
 
@@ -375,7 +375,7 @@ InstructionSet Zicsr extends RISCVBase {
     instructions {
         CSRRW {
             encoding: csr[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {name(rs1)}";
+            assembly:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
                 unsigned<XLEN> xrs1 = X[rs1];
                 if (rd != 0) {
@@ -391,7 +391,7 @@ InstructionSet Zicsr extends RISCVBase {
 
         CSRRS {
             encoding: csr[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {name(rs1)}";
+            assembly:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 unsigned<XLEN> xrs1 = X[rs1];
@@ -402,7 +402,7 @@ InstructionSet Zicsr extends RISCVBase {
 
         CSRRC {
             encoding: csr[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {name(rs1)}";
+            assembly:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 unsigned<XLEN> xrs1 = X[rs1];
@@ -413,7 +413,7 @@ InstructionSet Zicsr extends RISCVBase {
 
         CSRRWI {
             encoding: csr[11:0] :: zimm[4:0] :: 0b101 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
+            assembly:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 CSR[csr] = (unsigned<XLEN>)zimm;
@@ -423,7 +423,7 @@ InstructionSet Zicsr extends RISCVBase {
 
         CSRRSI {
             encoding: csr[11:0] :: zimm[4:0] :: 0b110 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
+            assembly:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 if (zimm != 0) CSR[csr] = xrd | (unsigned<XLEN>)zimm;
@@ -433,7 +433,7 @@ InstructionSet Zicsr extends RISCVBase {
 
         CSRRCI {
             encoding: csr[11:0] :: zimm[4:0] :: 0b111 :: rd[4:0] :: 0b1110011;
-            args_disass:"{name(rd)}, {csr}, {zimm:#0x}";
+            assembly:"{name(rd)}, {csr}, {zimm:#0x}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 if (zimm != 0) CSR[csr] = xrd & ~((unsigned<XLEN>)zimm);
@@ -447,7 +447,7 @@ InstructionSet Zifencei extends RISCVBase {
     instructions {
         FENCE_I [[flush]] {
             encoding: imm[11:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0001111 ;
-            args_disass:"{name(rs1)}, {name(rd)}, {imm}";
+            assembly:"{name(rs1)}, {name(rd)}, {imm}";
             behavior: FENCE[fencei] = imm;
         }
      }

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -17,8 +17,12 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[20:20] :: imm[10:1] :: imm[11:11] :: imm[19:12] :: rd[4:0] :: 0b1101111;
             args_disass: "{name(rd)}, {imm:#0x}";
             behavior: {
-            	if(rd!=0) X[rd] = PC+4;
-            	PC=PC+(signed<21>)imm;
+                if(imm % INSTR_ALIGNMENT) {
+                    raise(0, 0);
+                } else {
+                    if(rd!=0) X[rd] = PC+4;
+                    PC=PC+(signed<21>)imm;
+                }
         	}
         }
         JALR[[no_cont]]{
@@ -26,8 +30,7 @@ InstructionSet RV32I extends RISCVBase {
             args_disass: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
 	            signed<XLEN> new_pc = X[rs1] + (signed<12>)imm;
-	            signed<XLEN> align = new_pc & 0x2;
-	            if(align != 0){
+                if(new_pc % INSTR_ALIGNMENT) {
 	                raise(0, 0);
 	            } else {
 	                if(rd!=0) X[rd] = PC+4;
@@ -38,32 +41,70 @@ InstructionSet RV32I extends RISCVBase {
         BEQ[[no_cont]] [[cond]]{
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b000 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
-            behavior: if(X[rs1]==X[rs2]) PC = PC + (signed<13>)imm;
+            behavior: {
+                if(X[rs1]==X[rs2])
+                    if(imm % INSTR_ALIGNMENT) {
+                        raise(0, 0);
+                    } else 
+                        PC = PC + (signed<13>)imm;
+                
+            }
         }
         BNE[[no_cont]] [[cond]]{
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b001 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
-            behavior: if(X[rs1]!=X[rs2]) PC = PC + (signed<13>)imm;
+            behavior: {
+                if(X[rs1]!=X[rs2])
+                    if(imm % INSTR_ALIGNMENT) {
+                        raise(0, 0);
+                    } else 
+                        PC = PC + (signed<13>)imm;
+
+            }
         }
         BLT[[no_cont]] [[cond]]{
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b100 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
-            behavior: if((signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2]) PC = PC + (signed<13>)imm;
+            behavior: {
+                if((signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2])
+                    if(imm % INSTR_ALIGNMENT) {
+                        raise(0, 0);
+                    } else 
+                        PC = PC + (signed<13>)imm;
+            }
         }
         BGE[[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b101 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
-            behavior: if((signed<XLEN>)X[rs1] >= (signed<XLEN>)X[rs2]) PC = PC + (signed<13>)imm;
+            behavior: {
+                if((signed<XLEN>)X[rs1] >= (signed<XLEN>)X[rs2])
+                    if(imm % INSTR_ALIGNMENT) {
+                        raise(0, 0);
+                    } else 
+                        PC = PC + (signed<13>)imm;
+            }
         }
         BLTU[[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b110 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
-            behavior: if(X[rs1]<X[rs2]) PC = PC + (signed<13>)imm;
+            behavior: {
+                if(X[rs1]<X[rs2])
+                    if(imm % INSTR_ALIGNMENT) {
+                        raise(0, 0);
+                    } else 
+                        PC = PC + (signed<13>)imm;
+            }
         }
         BGEU[[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 0b111 :: imm[4:1] :: imm[11:11] :: 0b1100011;
             args_disass:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
-            behavior: if(X[rs1]>=X[rs2]) PC = PC + (signed<13>)imm;
+            behavior: {
+                if(X[rs1]>=X[rs2])
+                    if(imm % INSTR_ALIGNMENT) {
+                        raise(0, 0);
+                    } else 
+                        PC = PC + (signed<13>)imm;
+            }
         }
         LB {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0000011;

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -35,7 +35,7 @@ InstructionSet RV32I extends RISCVBase {
                 if (new_pc % INSTR_ALIGNMENT) {
                     raise(0, 0);
                 } else {
-                    if (rd != 0) X[rd] = PC+4;
+                    if (rd != 0) X[rd] = PC + 4;
                     PC = new_pc & ~0x1;
                 }
             }
@@ -211,13 +211,13 @@ InstructionSet RV32I extends RISCVBase {
         SLTI {
             encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] < (signed<12>)imm? 1 : 0;
+            behavior: if (rd != 0) X[rd] = ((signed<XLEN>)X[rs1] < (signed<12>)imm) ? 1 : 0;
         }
 
         SLTIU {
             encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if (rd != 0) X[rd] = (X[rs1] < (unsigned<XLEN>)((signed<12>)imm))? 1 : 0;
+            behavior: if (rd != 0) X[rd] = (X[rs1] < (unsigned<XLEN>)((signed<12>)imm)) ? 1 : 0;
         }
 
         XORI {
@@ -367,10 +367,10 @@ InstructionSet RV32I extends RISCVBase {
         DRET {
             encoding: 0b01111011001000000000000001110011;
             behavior: {
-                if(PRIV<4)
+                if (PRIV < 4)
                     raise(0, 2);
                 else {
-                    PC=DPC;
+                    PC = DPC;
                     PRIV &= 0x3;
                 }
             }

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -306,6 +306,17 @@ InstructionSet RV32I extends RISCVBase {
             encoding: 0b0001000 :: 0b00101 :: 0b00000 :: 0b000 :: 0b00000 :: 0b1110011;
             behavior: wait(1);
         }
+        DRET {
+            encoding: 0b01111011001000000000000001110011;
+            behavior: {
+                if(PRIV<4)
+                    raise(0, 2);
+                else {
+                    PC=DPC;
+                    PRIV &= 0x3;                    
+                }
+            }
+        }
     }
 }
 

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -21,7 +21,7 @@ InstructionSet RV32I extends RISCVBase {
                 if (imm % INSTR_ALIGNMENT) {
                     raise(0, 0);
                 } else {
-                    if (rd != 0) X[rd] = PC+4;
+                    if (rd != 0) X[rd] = PC + 4;
                     PC = PC + (signed<21>)imm;
                 }
             }

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -9,13 +9,13 @@ InstructionSet RV32I extends RISCVBase {
         LUI {
             encoding: imm[31:12] :: rd[4:0] :: 7'b0110111;
             assembly: "{name(rd)}, {imm:#05x}";
-            behavior: if (rd != 0) X[rd] = (signed<XLEN>)imm;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)imm;
         }
 
         AUIPC {
             encoding: imm[31:12] :: rd[4:0] :: 7'b0010111;
             assembly: "{name(rd)}, {imm:#08x}";
-            behavior: if (rd != 0) X[rd] = PC+(signed<XLEN>)imm;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = PC+(signed<XLEN>)imm;
         }
 
         JAL [[no_cont]] {
@@ -25,7 +25,7 @@ InstructionSet RV32I extends RISCVBase {
                 if (imm % INSTR_ALIGNMENT) {
                     raise(0, 0);
                 } else {
-                    if (rd != 0) X[rd] = PC + 4;
+                    if ((rd % RFS) != 0) X[rd % RFS] = PC + 4;
                     PC = PC + (signed<21>)imm;
                 }
             }
@@ -35,11 +35,11 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1100111;
             assembly: "{name(rd)}, {name(rs1)}, {imm:#0x}";
             behavior: {
-                unsigned<XLEN> new_pc = (X[rs1] + (signed<12>)imm) & ~0x1;
+                unsigned<XLEN> new_pc = (X[rs1 % RFS] + (signed<12>)imm) & ~0x1;
                 if (new_pc % INSTR_ALIGNMENT) {
                     raise(0, 0);
                 } else {
-                    if (rd != 0) X[rd] = PC + 4;
+                    if ((rd % RFS) != 0) X[rd % RFS] = PC + 4;
                     PC = new_pc & ~0x1;
                 }
             }
@@ -49,7 +49,7 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if (X[rs1] == X[rs2]) {
+                if (X[rs1 % RFS] == X[rs2 % RFS]) {
                     if(imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
                     } else {
@@ -63,7 +63,7 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if (X[rs1] != X[rs2]) {
+                if (X[rs1 % RFS] != X[rs2 % RFS]) {
                     if (imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
                     } else {
@@ -77,7 +77,7 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if ((signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2]) {
+                if ((signed<XLEN>)X[rs1 % RFS] < (signed<XLEN>)X[rs2 % RFS]) {
                     if (imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
                     } else {
@@ -91,7 +91,7 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if ((signed<XLEN>)X[rs1] >= (signed<XLEN>)X[rs2]) {
+                if ((signed<XLEN>)X[rs1 % RFS] >= (signed<XLEN>)X[rs2 % RFS]) {
                     if (imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
                     } else {
@@ -105,7 +105,7 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if (X[rs1] < X[rs2]) {
+                if (X[rs1 % RFS] < X[rs2 % RFS]) {
                     if (imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
                     } else {
@@ -119,7 +119,7 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
             assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: {
-                if (X[rs1] >= X[rs2]) {
+                if (X[rs1 % RFS] >= X[rs2 % RFS]) {
                     if (imm % INSTR_ALIGNMENT) {
                         raise(0, 0);
                     } else {
@@ -133,9 +133,9 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> load_address = X[rs1 % RFS] + (signed<12>)imm;
                 signed<8> res = (signed<8>)MEM[load_address];
-                if(rd != 0) X[rd] = (signed<XLEN>)res;
+                if((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)res;
             }
         }
 
@@ -143,9 +143,9 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> load_address = X[rs1 % RFS] + (signed<12>)imm;
                 signed<16> res = (signed<16>)MEM[load_address];
-                if (rd != 0) X[rd] = (signed<XLEN>)res;
+                if ((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)res;
              }
         }
 
@@ -153,9 +153,9 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> load_address = X[rs1 % RFS] + (signed<12>)imm;
                 signed<32> res = (signed<32>)MEM[load_address];
-                if (rd != 0) X[rd] = (signed<XLEN>)res;
+                if ((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)res;
             }
         }
 
@@ -163,9 +163,9 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> load_address = X[rs1 % RFS] + (signed<12>)imm;
                 unsigned<8> res = (unsigned<8>)MEM[load_address];
-                if (rd != 0) X[rd] = (unsigned<XLEN>)res;
+                if ((rd % RFS) != 0) X[rd % RFS] = (unsigned<XLEN>)res;
             }
         }
 
@@ -173,9 +173,9 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> load_address = X[rs1 % RFS] + (signed<12>)imm;
                 unsigned<16> res = (unsigned<16>)MEM[load_address];
-                if(rd != 0) X[rd] = (unsigned<XLEN>)res;
+                if((rd % RFS) != 0) X[rd % RFS] = (unsigned<XLEN>)res;
             }
         }
 
@@ -183,8 +183,8 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: imm[4:0] :: 7'b0100011;
             assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
-                MEM[store_address] = (signed<8>)X[rs2];
+                unsigned<XLEN> store_address = X[rs1 % RFS] + (signed<12>)imm;
+                MEM[store_address] = (signed<8>)X[rs2 % RFS];
             }
         }
 
@@ -192,8 +192,8 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: imm[4:0] :: 7'b0100011;
             assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
-                MEM[store_address] = (signed<16>)X[rs2];
+                unsigned<XLEN> store_address = X[rs1 % RFS] + (signed<12>)imm;
+                MEM[store_address] = (signed<16>)X[rs2 % RFS];
             }
         }
 
@@ -201,123 +201,123 @@ InstructionSet RV32I extends RISCVBase {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: imm[4:0] :: 7'b0100011;
             assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> store_address = X[rs1] + (signed<12>)imm;
-                MEM[store_address] = (signed<32>)X[rs2];
+                unsigned<XLEN> store_address = X[rs1 % RFS] + (signed<12>)imm;
+                MEM[store_address] = (signed<32>)X[rs2 % RFS];
             }
         }
 
         ADDI {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if (rd != 0) X[rd] = X[rs1] + (signed<12>)imm;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] + (signed<12>)imm;
         }
 
         SLTI {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if (rd != 0) X[rd] = ((signed<XLEN>)X[rs1] < (signed<12>)imm) ? 1 : 0;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = ((signed<XLEN>)X[rs1 % RFS] < (signed<12>)imm) ? 1 : 0;
         }
 
         SLTIU {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if (rd != 0) X[rd] = (X[rs1] < (unsigned<XLEN>)((signed<12>)imm)) ? 1 : 0;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = (X[rs1 % RFS] < (unsigned<XLEN>)((signed<12>)imm)) ? 1 : 0;
         }
 
         XORI {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if (rd != 0) X[rd] = X[rs1] ^ (signed<12>)imm;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] ^ (signed<12>)imm;
         }
 
         ORI {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if (rd != 0) X[rd] = X[rs1] | (signed<12>)imm;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] | (signed<12>)imm;
         }
 
         ANDI {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
-            behavior: if (rd != 0) X[rd] = X[rs1] & (signed<12>)imm;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] & (signed<12>)imm;
         }
 
         SLLI {
             encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if (rd != 0) X[rd] = X[rs1] << shamt;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] << shamt;
         }
 
         SRLI {
             encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if (rd != 0) X[rd] = X[rs1] >> shamt;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] >> shamt;
         }
 
         SRAI {
             encoding: 7'b0100000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> shamt;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)X[rs1 % RFS] >> shamt;
         }
 
         ADD {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = X[rs1] + X[rs2];
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] + X[rs2 % RFS];
         }
 
         SUB {
             encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = X[rs1] - X[rs2];
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] - X[rs2 % RFS];
         }
 
         SLL {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = X[rs1] << (X[rs2] & (XLEN - 1));
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] << (X[rs2 % RFS] & (XLEN - 1));
         }
 
         SLT {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2] ? 1 : 0;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)X[rs1 % RFS] < (signed<XLEN>)X[rs2 % RFS] ? 1 : 0;
         }
 
         SLTU {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-               behavior: if (rd != 0) X[rd] = (unsigned<XLEN>)X[rs1] < (unsigned<XLEN>)X[rs2] ? 1 : 0;
+               behavior: if ((rd % RFS) != 0) X[rd % RFS] = (unsigned<XLEN>)X[rs1 % RFS] < (unsigned<XLEN>)X[rs2 % RFS] ? 1 : 0;
         }
 
         XOR {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = X[rs1] ^ X[rs2];
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] ^ X[rs2 % RFS];
         }
 
         SRL {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = X[rs1] >> (X[rs2] & (XLEN - 1));
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] >> (X[rs2 % RFS] & (XLEN - 1));
         }
 
         SRA {
             encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = (signed<XLEN>)X[rs1] >> (X[rs2] & (XLEN - 1));
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)X[rs1 % RFS] >> (X[rs2 % RFS] & (XLEN - 1));
         }
 
         OR {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = X[rs1] | X[rs2];
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] | X[rs2 % RFS];
         }
 
         AND {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = X[rs1] & X[rs2];
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] & X[rs2 % RFS];
         }
 
         FENCE {
@@ -381,12 +381,12 @@ InstructionSet Zicsr extends RISCVBase {
             encoding: csr[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1110011;
             assembly:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
-                unsigned<XLEN> xrs1 = X[rs1];
-                if (rd != 0) {
+                unsigned<XLEN> xrs1 = X[rs1 % RFS];
+                if ((rd % RFS) != 0) {
                     unsigned<XLEN> xrd = CSR[csr];
                     CSR[csr] = xrs1;
                     // make sure Xrd is updated once CSR write succeeds
-                    X[rd] = xrd;
+                    X[rd % RFS] = xrd;
                 } else {
                     CSR[csr] = xrs1;
                 }
@@ -398,9 +398,9 @@ InstructionSet Zicsr extends RISCVBase {
             assembly:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
-                unsigned<XLEN> xrs1 = X[rs1];
+                unsigned<XLEN> xrs1 = X[rs1 % RFS];
                 if (rs1 != 0) CSR[csr] = xrd | xrs1;
-                if (rd != 0) X[rd] = xrd;
+                if ((rd % RFS) != 0) X[rd % RFS] = xrd;
             }
         }
 
@@ -409,9 +409,9 @@ InstructionSet Zicsr extends RISCVBase {
             assembly:"{name(rd)}, {csr}, {name(rs1)}";
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
-                unsigned<XLEN> xrs1 = X[rs1];
+                unsigned<XLEN> xrs1 = X[rs1 % RFS];
                 if (rs1 != 0) CSR[csr] = xrd & ~xrs1;
-                if (rd != 0) X[rd] = xrd;
+                if ((rd % RFS) != 0) X[rd % RFS] = xrd;
             }
         }
 
@@ -421,7 +421,7 @@ InstructionSet Zicsr extends RISCVBase {
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 CSR[csr] = (unsigned<XLEN>)zimm;
-                if (rd != 0) X[rd] = xrd;
+                if ((rd % RFS) != 0) X[rd % RFS] = xrd;
             }
         }
 
@@ -431,7 +431,7 @@ InstructionSet Zicsr extends RISCVBase {
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 if (zimm != 0) CSR[csr] = xrd | (unsigned<XLEN>)zimm;
-                if (rd != 0) X[rd] = xrd;
+                if ((rd % RFS) != 0) X[rd % RFS] = xrd;
             }
         }
 
@@ -441,7 +441,7 @@ InstructionSet Zicsr extends RISCVBase {
             behavior: {
                 unsigned<XLEN> xrd = CSR[csr];
                 if (zimm != 0) CSR[csr] = xrd & ~((unsigned<XLEN>)zimm);
-                if (rd != 0) X[rd] = xrd;
+                if ((rd % RFS) != 0) X[rd % RFS] = xrd;
             }
         }
     }

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -1,6 +1,10 @@
 import "RISCVBase.core_desc"
 
 InstructionSet RV32I extends RISCVBase {
+    architectural_state {
+        XLEN = 32;
+    }
+
     instructions {
         LUI {
             encoding: imm[31:12] :: rd[4:0] :: 7'b0110111;

--- a/RV64I.core_desc
+++ b/RV64I.core_desc
@@ -4,7 +4,7 @@ InstructionSet RV64I extends RV32I {
     instructions {
         LWU { // 80000104: 0000ef03 lwu t5,0(ra)
             encoding: imm[11:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -14,7 +14,7 @@ InstructionSet RV64I extends RV32I {
 
         LD {
             encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0000011;
-            args_disass:"{name(rd)}, {imm}({name(rs1)})";
+            assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 signed<64> res = (signed<64>)MEM[offs];
@@ -24,7 +24,7 @@ InstructionSet RV64I extends RV32I {
 
         SD {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: imm[4:0] :: 0b0100011;
-            args_disass:"{name(rs2)}, {imm}({name(rs1)})";
+            assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 MEM[offs] = (signed<64>)X[rs2];
@@ -33,25 +33,25 @@ InstructionSet RV64I extends RV32I {
 
         SLLI {
             encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = X[rs1] << shamt;
         }
 
         SRLI {
             encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = X[rs1] >> shamt;
         }
 
         SRAI {
             encoding: 0b010000 :: shamt[5:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = ((signed<XLEN>)X[rs1]) >> shamt;
         }
 
         ADDIW {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0011011;
-            args_disass:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: {
                 if (rd != 0) {
                     signed<32> res = X[rs1] + (signed<12>)imm;
@@ -62,7 +62,7 @@ InstructionSet RV64I extends RV32I {
 
         SLLIW {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0011011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
                 if (rd != 0) {
                     unsigned<32> sh_val = ((unsigned<32>)X[rs1]) <<  shamt;
@@ -73,7 +73,7 @@ InstructionSet RV64I extends RV32I {
 
         SRLIW {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0011011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
                 if (rd != 0) {
                     unsigned<32> sh_val = ((unsigned<32>)X[rs1]) >> shamt;
@@ -84,7 +84,7 @@ InstructionSet RV64I extends RV32I {
 
         SRAIW {
             encoding: 0b0100000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0011011;
-            args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
                 if (rd != 0) {
                     signed<32> sh_val = ((signed<32>)X[rs1]) >> shamt;
@@ -115,7 +115,7 @@ InstructionSet RV64I extends RV32I {
 
         SLLW {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     unsigned<32> count = (unsigned)X[rs2] & 0x1f;
@@ -127,7 +127,7 @@ InstructionSet RV64I extends RV32I {
 
         SRLW {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     unsigned<32> count = (unsigned)X[rs2] & 0x1f;
@@ -139,7 +139,7 @@ InstructionSet RV64I extends RV32I {
 
         SRAW {
             encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     unsigned<32> count = (unsigned)X[rs2] & 0x1f;

--- a/RV64I.core_desc
+++ b/RV64I.core_desc
@@ -3,7 +3,7 @@ import "RV32I.core_desc"
 InstructionSet RV64I extends RV32I {
     instructions {
         LWU { // 80000104: 0000ef03 lwu t5,0(ra)
-            encoding: imm[11:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0000011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
@@ -13,7 +13,7 @@ InstructionSet RV64I extends RV32I {
         }
 
         LD {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0000011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
@@ -23,7 +23,7 @@ InstructionSet RV64I extends RV32I {
         }
 
         SD {
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: imm[4:0] :: 0b0100011;
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: imm[4:0] :: 7'b0100011;
             assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
@@ -32,25 +32,25 @@ InstructionSet RV64I extends RV32I {
         }
 
         SLLI {
-            encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0010011;
+            encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = X[rs1] << shamt;
         }
 
         SRLI {
-            encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
+            encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = X[rs1] >> shamt;
         }
 
         SRAI {
-            encoding: 0b010000 :: shamt[5:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
+            encoding: 0b010000 :: shamt[5:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if (rd != 0) X[rd] = ((signed<XLEN>)X[rs1]) >> shamt;
         }
 
         ADDIW {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0011011;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0011011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: {
                 if (rd != 0) {
@@ -61,7 +61,7 @@ InstructionSet RV64I extends RV32I {
         }
 
         SLLIW {
-            encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0011011;
+            encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0011011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
                 if (rd != 0) {
@@ -72,7 +72,7 @@ InstructionSet RV64I extends RV32I {
         }
 
         SRLIW {
-            encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0011011;
+            encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0011011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
                 if (rd != 0) {
@@ -83,7 +83,7 @@ InstructionSet RV64I extends RV32I {
         }
 
         SRAIW {
-            encoding: 0b0100000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0011011;
+            encoding: 7'b0100000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0011011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
                 if (rd != 0) {
@@ -94,7 +94,7 @@ InstructionSet RV64I extends RV32I {
         }
 
         ADDW {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0111011;
             behavior: {
                 if (rd != 0) {
                     signed<32> res = (signed<32>)X[rs1] + (signed<32>)X[rs2];
@@ -104,7 +104,7 @@ InstructionSet RV64I extends RV32I {
         }
 
         SUBW {
-            encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0111011;
             behavior: {
                 if (rd != 0) {
                     signed<32> res = (signed<32>)X[rs1] - (signed<32>)X[rs2];
@@ -114,7 +114,7 @@ InstructionSet RV64I extends RV32I {
         }
 
         SLLW {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -126,7 +126,7 @@ InstructionSet RV64I extends RV32I {
         }
 
         SRLW {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -138,7 +138,7 @@ InstructionSet RV64I extends RV32I {
         }
 
         SRAW {
-            encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {

--- a/RV64I.core_desc
+++ b/RV64I.core_desc
@@ -40,13 +40,13 @@ InstructionSet RV64I extends RV32I {
         SRLI {
             encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if (rd != 0) X[rd] = ((unsigned<64>)X[rs1]) >> shamt;
+            behavior: if (rd != 0) X[rd] = X[rs1] >> shamt;
         }
 
         SRAI {
             encoding: 0b010000 :: shamt[5:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if (rd != 0) X[rd] = ((signed<64>)X[rs1]) >> shamt;
+            behavior: if (rd != 0) X[rd] = ((signed<XLEN>)X[rs1]) >> shamt;
         }
 
         ADDIW {
@@ -54,7 +54,7 @@ InstructionSet RV64I extends RV32I {
             args_disass:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: {
                 if (rd != 0) {
-                    unsigned<32> res = X[rs1] + (signed<12>)imm;
+                    signed<32> res = X[rs1] + (signed<12>)imm;
                     X[rd] = res;
                 }
             }

--- a/RV64I.core_desc
+++ b/RV64I.core_desc
@@ -10,9 +10,9 @@ InstructionSet RV64I extends RV32I {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
-                if (rd != 0) X[rd] = (unsigned<XLEN>)res;
+                if ((rd % RFS) != 0) X[rd % RFS] = (unsigned<XLEN>)res;
             }
         }
 
@@ -20,9 +20,9 @@ InstructionSet RV64I extends RV32I {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0000011;
             assembly:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 signed<64> res = (signed<64>)MEM[offs];
-                if (rd != 0) X[rd] = (signed<XLEN>)res;
+                if ((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)res;
             }
         }
 
@@ -30,36 +30,36 @@ InstructionSet RV64I extends RV32I {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: imm[4:0] :: 7'b0100011;
             assembly:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
-                MEM[offs] = (signed<64>)X[rs2];
+                unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
+                MEM[offs] = (signed<64>)X[rs2 % RFS];
             }
         }
 
         SLLI {
             encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if (rd != 0) X[rd] = X[rs1] << shamt;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] << shamt;
         }
 
         SRLI {
             encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if (rd != 0) X[rd] = X[rs1] >> shamt;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs1 % RFS] >> shamt;
         }
 
         SRAI {
             encoding: 0b010000 :: shamt[5:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if (rd != 0) X[rd] = ((signed<XLEN>)X[rs1]) >> shamt;
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = ((signed<XLEN>)X[rs1 % RFS]) >> shamt;
         }
 
         ADDIW {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0011011;
             assembly:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: {
-                if (rd != 0) {
-                    signed<32> res = X[rs1] + (signed<12>)imm;
-                    X[rd] = res;
+                if ((rd % RFS) != 0) {
+                    signed<32> res = X[rs1 % RFS] + (signed<12>)imm;
+                    X[rd % RFS] = (signed<64>)res;
                 }
             }
         }
@@ -68,9 +68,9 @@ InstructionSet RV64I extends RV32I {
             encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0011011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
-                if (rd != 0) {
-                    unsigned<32> sh_val = ((unsigned<32>)X[rs1]) <<  shamt;
-                    X[rd] = (signed<64>)sh_val;
+                if ((rd % RFS) != 0) {
+                    unsigned<32> sh_val = ((unsigned<32>)X[rs1 % RFS]) <<  shamt;
+                    X[rd % RFS] = (signed<64>)sh_val;
                 }
             }
         }
@@ -79,9 +79,9 @@ InstructionSet RV64I extends RV32I {
             encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0011011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
-                if (rd != 0) {
-                    unsigned<32> sh_val = ((unsigned<32>)X[rs1]) >> shamt;
-                    X[rd] = (signed<64>)sh_val;
+                if ((rd % RFS) != 0) {
+                    unsigned<32> sh_val = ((unsigned<32>)X[rs1 % RFS]) >> shamt;
+                    X[rd % RFS] = (signed<64>)sh_val;
                 }
             }
         }
@@ -90,9 +90,9 @@ InstructionSet RV64I extends RV32I {
             encoding: 7'b0100000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0011011;
             assembly:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
-                if (rd != 0) {
-                    signed<32> sh_val = ((signed<32>)X[rs1]) >> shamt;
-                    X[rd] = (signed<64>)sh_val;
+                if ((rd % RFS) != 0) {
+                    signed<32> sh_val = ((signed<32>)X[rs1 % RFS]) >> shamt;
+                    X[rd % RFS] = (signed<64>)sh_val;
                 }
             }
         }
@@ -100,9 +100,9 @@ InstructionSet RV64I extends RV32I {
         ADDW {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0111011;
             behavior: {
-                if (rd != 0) {
-                    signed<32> res = (signed<32>)X[rs1] + (signed<32>)X[rs2];
-                    X[rd] = (signed<64>)res;
+                if ((rd % RFS) != 0) {
+                    signed<32> res = (signed<32>)X[rs1 % RFS] + (signed<32>)X[rs2 % RFS];
+                    X[rd % RFS] = (signed<64>)res;
                 }
             }
         }
@@ -110,9 +110,9 @@ InstructionSet RV64I extends RV32I {
         SUBW {
             encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0111011;
             behavior: {
-                if (rd != 0) {
-                    signed<32> res = (signed<32>)X[rs1] - (signed<32>)X[rs2];
-                    X[rd] = (signed<64>)res;
+                if ((rd % RFS) != 0) {
+                    signed<32> res = (signed<32>)X[rs1 % RFS] - (signed<32>)X[rs2 % RFS];
+                    X[rd % RFS] = (signed<64>)res;
                 }
             }
         }
@@ -121,10 +121,10 @@ InstructionSet RV64I extends RV32I {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    unsigned<32> count = (unsigned)X[rs2] & 0x1f;
-                    unsigned<32> sh_val = ((unsigned<32>)X[rs1]) << count;
-                    X[rd] = (unsigned<64>)sh_val;
+                if ((rd % RFS) != 0) {
+                    unsigned<32> count = (unsigned)X[rs2 % RFS] & 0x1f;
+                    unsigned<32> sh_val = ((unsigned<32>)X[rs1 % RFS]) << count;
+                    X[rd % RFS] = (unsigned<64>)sh_val;
                 }
             }
         }
@@ -133,10 +133,10 @@ InstructionSet RV64I extends RV32I {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    unsigned<32> count = (unsigned)X[rs2] & 0x1f;
-                    unsigned<32> sh_val = ((unsigned<32>)X[rs1]) >> count;
-                    X[rd] = (unsigned<64>)sh_val;
+                if ((rd % RFS) != 0) {
+                    unsigned<32> count = (unsigned)X[rs2 % RFS] & 0x1f;
+                    unsigned<32> sh_val = ((unsigned<32>)X[rs1 % RFS]) >> count;
+                    X[rd % RFS] = (unsigned<64>)sh_val;
                 }
             }
         }
@@ -145,10 +145,10 @@ InstructionSet RV64I extends RV32I {
             encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    unsigned<32> count = (unsigned)X[rs2] & 0x1f;
-                    signed<32> sh_val = ((signed<32>)X[rs1]) >> count;
-                    X[rd] = (signed<64>)sh_val;
+                if ((rd % RFS) != 0) {
+                    unsigned<32> count = (unsigned)X[rs2 % RFS] & 0x1f;
+                    signed<32> sh_val = ((signed<32>)X[rs1 % RFS]) >> count;
+                    X[rd % RFS] = (signed<64>)sh_val;
                 }
             }
         }

--- a/RV64I.core_desc
+++ b/RV64I.core_desc
@@ -7,7 +7,8 @@ InstructionSet RV64I extends RV32I {
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
-                if (rd != 0) X[rd] = (unsigned<32>)MEM[offs];
+                unsigned<32> res = (unsigned<32>)MEM[offs];
+                if (rd != 0) X[rd] = (unsigned<XLEN>)res;
             }
         }
 
@@ -16,7 +17,8 @@ InstructionSet RV64I extends RV32I {
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
-                if (rd != 0) X[rd] = (unsigned<64>)MEM[offs];
+                signed<64> res = (signed<64>)MEM[offs];
+                if (rd != 0) X[rd] = (signed<XLEN>)res;
             }
         }
 
@@ -25,7 +27,7 @@ InstructionSet RV64I extends RV32I {
             args_disass:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
-                MEM[offs] = X[rs2];
+                MEM[offs] = (signed<64>)X[rs2];
             }
         }
 

--- a/RV64I.core_desc
+++ b/RV64I.core_desc
@@ -1,137 +1,150 @@
 import "RV32I.core_desc"
 
 InstructionSet RV64I extends RV32I {
-    instructions{
-        LWU { //    80000104: 0000ef03            lwu t5,0(ra)
+    instructions {
+        LWU { // 80000104: 0000ef03 lwu t5,0(ra)
             encoding: imm[11:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0000011;
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-	            unsigned offs = X[rs1]+(signed<12>)imm;
-	            if(rd!=0) X[rd]=(unsigned<32>)MEM[offs];
+                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
+                if (rd != 0) X[rd] = (unsigned<32>)MEM[offs];
             }
         }
-        LD{
+
+        LD {
             encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0000011;
             args_disass:"{name(rd)}, {imm}({name(rs1)})";
             behavior: {
-	            unsigned offs = X[rs1] + (signed<12>)imm;
-	            if(rd!=0) X[rd]=(unsigned<64>)MEM[offs];
+                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
+                if (rd != 0) X[rd] = (unsigned<64>)MEM[offs];
             }
         }
-        SD{
+
+        SD {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: imm[4:0] :: 0b0100011;
             args_disass:"{name(rs2)}, {imm}({name(rs1)})";
             behavior: {
-            	unsigned offs = X[rs1] + (signed<12>)imm;
-            	MEM[offs] = X[rs2];
+                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
+                MEM[offs] = X[rs2];
             }
         }
+
         SLLI {
             encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if(rd != 0) X[rd] = X[rs1] << shamt;
+            behavior: if (rd != 0) X[rd] = X[rs1] << shamt;
         }
+
         SRLI {
             encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if(rd != 0) X[rd] = ((unsigned<64>)X[rs1])>>shamt;
+            behavior: if (rd != 0) X[rd] = ((unsigned<64>)X[rs1]) >> shamt;
         }
+
         SRAI {
             encoding: 0b010000 :: shamt[5:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0010011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
-            behavior: if(rd != 0) X[rd] = ((signed<64>)X[rs1])>>shamt;
+            behavior: if (rd != 0) X[rd] = ((signed<64>)X[rs1]) >> shamt;
         }
+
         ADDIW {
             encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0011011;
             args_disass:"{name(rd)}, {name(rs1)}, {imm}";
             behavior: {
-	            if(rd != 0){
-	                unsigned<32> res = X[rs1] + (signed<12>)imm;
-	                X[rd] = res;
-	            } 
+                if (rd != 0) {
+                    unsigned<32> res = X[rs1] + (signed<12>)imm;
+                    X[rd] = res;
+                }
             }
         }
+
         SLLIW {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0011011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
-	            if(rd != 0){
-	                unsigned<32> sh_val = ((unsigned<32>)X[rs1])<< shamt;
-	                X[rd] = (signed<64>)sh_val;
-	            } 
+                if (rd != 0) {
+                    unsigned<32> sh_val = ((unsigned<32>)X[rs1]) <<  shamt;
+                    X[rd] = (signed<64>)sh_val;
+                }
             }
         }
+
         SRLIW {
             encoding: 0b0000000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0011011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
-	            if(rd != 0){
-	                unsigned<32> sh_val =((unsigned<32>)X[rs1])>> shamt;
-	                X[rd] = (signed<64>)sh_val;
-	            }           
+                if (rd != 0) {
+                    unsigned<32> sh_val = ((unsigned<32>)X[rs1]) >> shamt;
+                    X[rd] = (signed<64>)sh_val;
+                }
             }
         }
+
         SRAIW {
             encoding: 0b0100000 :: shamt[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0011011;
             args_disass:"{name(rd)}, {name(rs1)}, {shamt}";
             behavior: {
-	            if(rd != 0){
-	                signed<32> sh_val = ((signed<32>)X[rs1])>> shamt;    
-	                X[rd] = (signed<64>)sh_val;
-	            }
+                if (rd != 0) {
+                    signed<32> sh_val = ((signed<32>)X[rs1]) >> shamt;
+                    X[rd] = (signed<64>)sh_val;
+                }
             }
         }
+
         ADDW {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
             behavior: {
-	            if(rd != 0){
-	                signed<32> res = (signed<32>)X[rs1] + (signed<32>)X[rs2];
-	                X[rd] = (signed<64>)res;
-	            } 
+                if (rd != 0) {
+                    signed<32> res = (signed<32>)X[rs1] + (signed<32>)X[rs2];
+                    X[rd] = (signed<64>)res;
+                }
             }
         }
+
         SUBW {
             encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
             behavior: {
-            	if(rd != 0){
-	                signed<32> res = (signed<32>)X[rs1] - (signed<32>)X[rs2];
-	                X[rd] = (signed<64>)res;
-	            } 
+                if (rd != 0) {
+                    signed<32> res = (signed<32>)X[rs1] - (signed<32>)X[rs2];
+                    X[rd] = (signed<64>)res;
+                }
             }
         }
+
         SLLW {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                unsigned count = (unsigned)X[rs2] & 0x1f;
-	                unsigned<32> sh_val =((unsigned<32>)X[rs1]) << count;
-	                X[rd] = (unsigned<64>)sh_val;
-	            } 
+                if (rd != 0) {
+                    unsigned<32> count = (unsigned)X[rs2] & 0x1f;
+                    unsigned<32> sh_val = ((unsigned<32>)X[rs1]) << count;
+                    X[rd] = (unsigned<64>)sh_val;
+                }
             }
         }
+
         SRLW {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-    	        if(rd != 0){
-	                unsigned count = (unsigned)X[rs2] & 0x1f;
-	                unsigned<32> sh_val =((unsigned<32>)X[rs1]) >> count;
-	                X[rd] = (unsigned<64>)sh_val;
-	            } 
+                if (rd != 0) {
+                    unsigned<32> count = (unsigned)X[rs2] & 0x1f;
+                    unsigned<32> sh_val = ((unsigned<32>)X[rs1]) >> count;
+                    X[rd] = (unsigned<64>)sh_val;
+                }
             }
         }
+
         SRAW {
             encoding: 0b0100000 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                unsigned count = (unsigned)X[rs2] & 0x1f;
-	                signed<32> sh_val =((signed<32>)X[rs1]) >> count;
-	                X[rd] = (signed<64>)sh_val;
-    	        } 
+                if (rd != 0) {
+                    unsigned<32> count = (unsigned)X[rs2] & 0x1f;
+                    signed<32> sh_val = ((signed<32>)X[rs1]) >> count;
+                    X[rd] = (signed<64>)sh_val;
+                }
             }
         }
-    }    
+    }
 }
-

--- a/RV64I.core_desc
+++ b/RV64I.core_desc
@@ -1,6 +1,10 @@
 import "RV32I.core_desc"
 
 InstructionSet RV64I extends RV32I {
+    architectural_state {
+        XLEN = 64;
+    }
+
     instructions {
         LWU { // 80000104: 0000ef03 lwu t5,0(ra)
             encoding: imm[11:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0000011;

--- a/RVA.core_desc
+++ b/RVA.core_desc
@@ -3,7 +3,7 @@ import "RISCVBase.core_desc"
 InstructionSet RV32A extends RISCVBase {
     instructions {
         LRW {
-            encoding: 0b00010 :: aq[0:0] :: rl[0:0] :: 0b00000 :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b00010 :: aq[0:0] :: rl[0:0]  :: 5'b00000 :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(aq)}, {name(rl)}";
             behavior: if (rd != 0) {
                 unsigned<XLEN> offs = X[rs1];
@@ -13,7 +13,7 @@ InstructionSet RV32A extends RISCVBase {
         }
 
         SCW {
-            encoding: 0b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}, {name(aq)}, {name(rl)}";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -26,7 +26,7 @@ InstructionSet RV32A extends RISCVBase {
         }
 
         AMOSWAPW {
-            encoding: 0b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -36,7 +36,7 @@ InstructionSet RV32A extends RISCVBase {
         }
 
         AMOADDW {
-            encoding: 0b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -48,7 +48,7 @@ InstructionSet RV32A extends RISCVBase {
         }
 
         AMOXORW {
-            encoding: 0b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -60,7 +60,7 @@ InstructionSet RV32A extends RISCVBase {
         }
 
         AMOANDW {
-            encoding: 0b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -72,7 +72,7 @@ InstructionSet RV32A extends RISCVBase {
         }
 
         AMOORW {
-            encoding: 0b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -84,7 +84,7 @@ InstructionSet RV32A extends RISCVBase {
         }
 
         AMOMINW {
-            encoding: 0b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -96,7 +96,7 @@ InstructionSet RV32A extends RISCVBase {
         }
 
         AMOMAXW {
-            encoding: 0b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -108,7 +108,7 @@ InstructionSet RV32A extends RISCVBase {
         }
 
         AMOMINUW {
-            encoding: 0b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -120,7 +120,7 @@ InstructionSet RV32A extends RISCVBase {
         }
 
         AMOMAXUW {
-            encoding: 0b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -136,7 +136,7 @@ InstructionSet RV32A extends RISCVBase {
 InstructionSet RV64A extends RV32A {
     instructions {
         LRD {
-            encoding: 0b00010 :: aq[0:0] :: rl[0:0] :: 0b00000 :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b00010 :: aq[0:0] :: rl[0:0]  :: 5'b00000 :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}";
             behavior: {
                 if (rd != 0) {
@@ -148,7 +148,7 @@ InstructionSet RV64A extends RV32A {
         }
 
         SCD {
-            encoding: 0b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
             unsigned<XLEN> offs = X[rs1];
@@ -163,7 +163,7 @@ InstructionSet RV64A extends RV32A {
         }
 
         AMOSWAPD {
-            encoding: 0b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -173,7 +173,7 @@ InstructionSet RV64A extends RV32A {
         }
 
         AMOADDD {
-            encoding: 0b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -185,7 +185,7 @@ InstructionSet RV64A extends RV32A {
         }
 
         AMOXORD {
-            encoding: 0b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -197,7 +197,7 @@ InstructionSet RV64A extends RV32A {
         }
 
         AMOANDD {
-            encoding: 0b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -209,7 +209,7 @@ InstructionSet RV64A extends RV32A {
         }
 
         AMOORD {
-            encoding: 0b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -221,7 +221,7 @@ InstructionSet RV64A extends RV32A {
         }
 
         AMOMIND {
-            encoding: 0b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -233,7 +233,7 @@ InstructionSet RV64A extends RV32A {
         }
 
         AMOMAXD {
-            encoding: 0b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -245,7 +245,7 @@ InstructionSet RV64A extends RV32A {
         }
 
         AMOMINUD {
-            encoding: 0b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
@@ -257,7 +257,7 @@ InstructionSet RV64A extends RV32A {
         }
 
         AMOMAXUD {
-            encoding: 0b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 5'b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];

--- a/RVA.core_desc
+++ b/RVA.core_desc
@@ -4,7 +4,7 @@ InstructionSet RV32A extends RISCVBase {
     instructions {
         LRW {
             encoding: 0b00010 :: aq[0:0] :: rl[0:0] :: 0b00000 :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(aq)}, {name(rl)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(aq)}, {name(rl)}";
             behavior: if (rd != 0) {
                 unsigned<XLEN> offs = X[rs1];
                 X[rd] = (signed<32>)MEM[offs];
@@ -14,7 +14,7 @@ InstructionSet RV32A extends RISCVBase {
 
         SCW {
             encoding: 0b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)}, {name(aq)}, {name(rl)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}, {name(aq)}, {name(rl)}";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 unsigned<32> res1 = RES[offs];
@@ -27,7 +27,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOSWAPW {
             encoding: 0b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 if (rd != 0) X[rd] = (signed<32>)MEM[offs];
@@ -37,7 +37,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOADDW {
             encoding: 0b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<32> res1 = MEM[offs];
@@ -49,7 +49,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOXORW {
             encoding: 0b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<32> res1 = MEM[offs];
@@ -61,7 +61,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOANDW {
             encoding: 0b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<32> res1 = MEM[offs];
@@ -73,7 +73,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOORW {
             encoding: 0b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<32> res1 = MEM[offs];
@@ -85,7 +85,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOMINW {
             encoding: 0b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<32> res1 = MEM[offs];
@@ -97,7 +97,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOMAXW {
             encoding: 0b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<32> res1 = MEM[offs];
@@ -109,7 +109,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOMINUW {
             encoding: 0b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 unsigned<32> res1 = MEM[offs];
@@ -121,7 +121,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOMAXUW {
             encoding: 0b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 unsigned<32> res1 = MEM[offs];
@@ -137,7 +137,7 @@ InstructionSet RV64A extends RV32A {
     instructions {
         LRD {
             encoding: 0b00010 :: aq[0:0] :: rl[0:0] :: 0b00000 :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}";
+            assembly: "{name(rd)}, {name(rs1)}";
             behavior: {
                 if (rd != 0) {
                     unsigned<XLEN> offs = X[rs1];
@@ -149,7 +149,7 @@ InstructionSet RV64A extends RV32A {
 
         SCD {
             encoding: 0b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
             unsigned<XLEN> offs = X[rs1];
             unsigned<XLEN> res[64] = RES[offs];
@@ -164,7 +164,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOSWAPD {
             encoding: 0b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 if (rd != 0) X[rd] = MEM[offs];
@@ -174,7 +174,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOADDD {
             encoding: 0b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<XLEN> res = MEM[offs];
@@ -186,7 +186,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOXORD {
             encoding: 0b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<XLEN> res = MEM[offs];
@@ -198,7 +198,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOANDD {
             encoding: 0b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<XLEN> res = MEM[offs];
@@ -210,7 +210,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOORD {
             encoding: 0b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<XLEN> res = MEM[offs];
@@ -222,7 +222,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOMIND {
             encoding: 0b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<XLEN> res1 = MEM[offs];
@@ -234,7 +234,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOMAXD {
             encoding: 0b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 signed<XLEN> res = MEM[offs];
@@ -246,7 +246,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOMINUD {
             encoding: 0b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 unsigned<XLEN> res = MEM[offs];
@@ -258,7 +258,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOMAXUD {
             encoding: 0b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
                 unsigned<XLEN> res1 = MEM[offs];

--- a/RVA.core_desc
+++ b/RVA.core_desc
@@ -40,9 +40,9 @@ InstructionSet RV32A extends RISCVBase {
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res1 = MEM[offs];
+                signed<32> res1 = MEM[offs];
                 if (rd != 0) X[rd] = res1;
-                unsigned<XLEN> res2 = res1 + X[rs2];
+                unsigned<32> res2 = res1 + X[rs2];
                 MEM[offs] = res2;
             }
         }
@@ -52,9 +52,9 @@ InstructionSet RV32A extends RISCVBase {
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res1 = MEM[offs];
+                signed<32> res1 = MEM[offs];
                 if (rd != 0) X[rd] = res1;
-                unsigned<XLEN> res2 = res1 ^ X[rs2];
+                unsigned<32> res2 = res1 ^ X[rs2];
                 MEM[offs] = res2;
             }
         }
@@ -64,9 +64,9 @@ InstructionSet RV32A extends RISCVBase {
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res1 = MEM[offs];
+                signed<32> res1 = MEM[offs];
                 if (rd != 0) X[rd] = res1;
-                unsigned<XLEN> res2 = res1 & X[rs2];
+                unsigned<32> res2 = res1 & X[rs2];
                 MEM[offs] = res2;
             }
         }
@@ -76,9 +76,9 @@ InstructionSet RV32A extends RISCVBase {
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res1 = MEM[offs];
+                signed<32> res1 = MEM[offs];
                 if (rd != 0) X[rd] = res1;
-                unsigned<XLEN> res2 = res1 | X[rs2];
+                unsigned<32> res2 = res1 | X[rs2];
                 MEM[offs] = res2;
             }
         }
@@ -88,9 +88,9 @@ InstructionSet RV32A extends RISCVBase {
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res1 = MEM[offs];
+                signed<32> res1 = MEM[offs];
                 if (rd != 0) X[rd] = res1;
-                unsigned<XLEN> res2 = (signed<XLEN>)res1 > (signed<XLEN>)X[rs2] ? X[rs2] : res1;
+                unsigned<32> res2 = res1 > (signed<32>)X[rs2] ? X[rs2] : res1;
                 MEM[offs] = res2;
             }
         }
@@ -100,9 +100,9 @@ InstructionSet RV32A extends RISCVBase {
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res1 = MEM[offs];
+                signed<32> res1 = MEM[offs];
                 if (rd != 0) X[rd] = res1;
-                unsigned<XLEN> res2 = res1<(signed<XLEN>) X[rs2] ? X[rs2] : res1;
+                unsigned<32> res2 = res1 < (signed<32>)X[rs2] ? X[rs2] : res1;
                 MEM[offs] = res2;
             }
         }
@@ -112,9 +112,9 @@ InstructionSet RV32A extends RISCVBase {
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res1 = MEM[offs];
-                if (rd != 0) X[rd] = res1;
-                unsigned<XLEN> res2 = res1>(signed<XLEN>)X[rs2] ? X[rs2] : res1;
+                unsigned<32> res1 = MEM[offs];
+                if (rd != 0) X[rd] = (signed<32>)res1;
+                unsigned<32> res2 = res1 > X[rs2] ? X[rs2] : res1;
                 MEM[offs] = res2;
             }
         }
@@ -124,9 +124,9 @@ InstructionSet RV32A extends RISCVBase {
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res1 = MEM[offs];
-                if (rd != 0) X[rd] = res1;
-                unsigned<XLEN> res2 = res1 < X[rs2] ? X[rs2] : res1;
+                unsigned<32> res1 = MEM[offs];
+                if (rd != 0) X[rd] = (signed<32>)res1;
+                unsigned<32> res2 = res1 < X[rs2] ? X[rs2] : res1;
                 MEM[offs] = res2;
             }
         }

--- a/RVA.core_desc
+++ b/RVA.core_desc
@@ -1,252 +1,270 @@
 import "RISCVBase.core_desc"
 
 InstructionSet RV32A extends RISCVBase {
-     
-    instructions{
+    instructions {
         LRW {
-            encoding: 0b00010 :: aq[0:0] :: rl[0:0]  :: 0b00000 :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
+            encoding: 0b00010 :: aq[0:0] :: rl[0:0] :: 0b00000 :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(aq)}, {name(rl)}";
-            behavior: if(rd!=0){
+            behavior: if (rd != 0) {
                 unsigned<XLEN> offs = X[rs1];
-                X[rd] = (int<32>)MEM[offs];
-                RES[offs]=-1;
+                X[rd] = (signed<32>)MEM[offs];
+                RES[offs] = -1;
             }
         }
+
         SCW {
             encoding: 0b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)}, {name(aq)}, {name(rl)}";
-            behavior:  {
-				unsigned<XLEN> offs = X[rs1];
-            	unsigned<32>  res1 = RES[offs];
-            	if(res1!=0)
-                	MEM[offs] = X[rs2];
-            	if(rd!=0)
-            		X[rd] = res1? 0: 1;
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                unsigned<32> res1 = RES[offs];
+                if (res1 != 0)
+                    MEM[offs] = X[rs2];
+                if (rd != 0)
+                    X[rd] = res1 ? 0 : 1;
             }
         }
-        AMOSWAPW{
+
+        AMOSWAPW {
             encoding: 0b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN> offs=X[rs1];
-	            if(rd!=0) X[rd]=(signed<32>)MEM[offs];
-	            MEM[offs]=X[rs2];
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                if (rd != 0) X[rd] = (signed<32>)MEM[offs];
+                MEM[offs] = X[rs2];
             }
         }
-        AMOADDW{
+
+        AMOADDW {
             encoding: 0b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2 =res1 + X[rs2];
-	            MEM[offs]=res2;
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res1 = MEM[offs];
+                if (rd != 0) X[rd] = res1;
+                unsigned<XLEN> res2 = res1 + X[rs2];
+                MEM[offs] = res2;
             }
         }
-        AMOXORW{
+
+        AMOXORW {
             encoding: 0b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN> offs = X[rs1];
-	            signed<XLEN> res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2 =res1 ^ X[rs2];
-	            MEM[offs]=res2;
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res1 = MEM[offs];
+                if (rd != 0) X[rd] = res1;
+                unsigned<XLEN> res2 = res1 ^ X[rs2];
+                MEM[offs] = res2;
             }
         }
-        AMOANDW{
+
+        AMOANDW {
             encoding: 0b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN> offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2 =res1 & X[rs2];
-	            MEM[offs]=res2;
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res1 = MEM[offs];
+                if (rd != 0) X[rd] = res1;
+                unsigned<XLEN> res2 = res1 & X[rs2];
+                MEM[offs] = res2;
             }
         }
+
         AMOORW {
             encoding: 0b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2=res1 :: X[rs2];
-	            MEM[offs]=res2;
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res1 = MEM[offs];
+                if (rd != 0) X[rd] = res1;
+                unsigned<XLEN> res2 = res1 | X[rs2];
+                MEM[offs] = res2;
             }
         }
-        AMOMINW{
+
+        AMOMINW {
             encoding: 0b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd] = res1;
-	            unsigned<XLEN>  res2 = (signed<XLEN>)res1 > (signed<XLEN>)X[rs2]? X[rs2]: res1;
-	            MEM[offs] = res2;
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res1 = MEM[offs];
+                if (rd != 0) X[rd] = res1;
+                unsigned<XLEN> res2 = (signed<XLEN>)res1 > (signed<XLEN>)X[rs2] ? X[rs2] : res1;
+                MEM[offs] = res2;
             }
         }
-        AMOMAXW{
+
+        AMOMAXW {
             encoding: 0b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2= res1<(signed<XLEN>) X[rs2]? X[rs2] : res1;
-	            MEM[offs]=res2;
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res1 = MEM[offs];
+                if (rd != 0) X[rd] = res1;
+                unsigned<XLEN> res2 = res1<(signed<XLEN>) X[rs2] ? X[rs2] : res1;
+                MEM[offs] = res2;
             }
         }
-        AMOMINUW{
+
+        AMOMINUW {
             encoding: 0b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd]=res1;
-	            unsigned<XLEN>  res2= res1>(signed<XLEN>)X[rs2]? X[rs2] : res1;
-	            MEM[offs]=res2;
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res1 = MEM[offs];
+                if (rd != 0) X[rd] = res1;
+                unsigned<XLEN> res2 = res1>(signed<XLEN>)X[rs2] ? X[rs2] : res1;
+                MEM[offs] = res2;
             }
         }
-        AMOMAXUW{
+
+        AMOMAXUW {
             encoding: 0b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs=X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd] = res1;
-	            unsigned<XLEN>  res2 = res1 < X[rs2]? X[rs2] : res1;
-	            MEM[offs] = res2;
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res1 = MEM[offs];
+                if (rd != 0) X[rd] = res1;
+                unsigned<XLEN> res2 = res1 < X[rs2] ? X[rs2] : res1;
+                MEM[offs] = res2;
             }
         }
     }
 }
 
 InstructionSet RV64A extends RV32A {
-     
-    instructions{
+    instructions {
         LRD {
-            encoding: 0b00010 :: aq[0:0] :: rl[0:0]  :: 0b00000 :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
+            encoding: 0b00010 :: aq[0:0] :: rl[0:0] :: 0b00000 :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}";
-            behavior:  {
-	            if(rd!=0){
-	                unsigned<XLEN>  offs = X[rs1];
-	                X[rd]= (signed<XLEN> )MEM[offs];
-	                RES[offs]=-1;
-	            }
+            behavior: {
+                if (rd != 0) {
+                    unsigned<XLEN> offs = X[rs1];
+                    X[rd] = (signed<XLEN>)MEM[offs];
+                    RES[offs] = -1;
+                }
             }
         }
+
         SCD {
             encoding: 0b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
             args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)}";
-            behavior:  {
-            unsigned<XLEN>  offs = X[rs1];
-            unsigned<XLEN>  res[64] = RES[offs];
-	            if(res!=0){
-	                MEM[offs] = X[rs2];
-	                if(rd!=0) X[rd]=0;
-	            } else{ 
-	                if(rd!=0) X[rd]= 1;
-	            }
+            behavior: {
+            unsigned<XLEN> offs = X[rs1];
+            unsigned<XLEN> res[64] = RES[offs];
+                if (res != 0) {
+                    MEM[offs] = X[rs2];
+                    if (rd != 0) X[rd] = 0;
+                } else {
+                    if (rd != 0) X[rd] = 1;
+                }
             }
         }
-        AMOSWAPD{
+
+        AMOSWAPD {
             encoding: 0b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            if(rd!=0) X[rd] = MEM[offs];
-	            MEM[offs] = X[rs2];            
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                if (rd != 0) X[rd] = MEM[offs];
+                MEM[offs] = X[rs2];
             }
         }
-        AMOADDD{
+
+        AMOADDD {
             encoding: 0b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd]=res;
-	            unsigned<XLEN>  res2 = res + X[rs2];
-	            MEM[offs]=res2;            
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res = MEM[offs];
+                if (rd != 0) X[rd] = res;
+                unsigned<XLEN> res2 = res + X[rs2];
+                MEM[offs] = res2;
             }
         }
-        AMOXORD{
+
+        AMOXORD {
             encoding: 0b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd] = res;
-	            unsigned<XLEN>  res2 = res ^ X[rs2];
-	            MEM[offs] = res2;            
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res = MEM[offs];
+                if (rd != 0) X[rd] = res;
+                unsigned<XLEN> res2 = res ^ X[rs2];
+                MEM[offs] = res2;
             }
         }
-        AMOANDD{
+
+        AMOANDD {
             encoding: 0b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd] = res;
-	            unsigned<XLEN>  res2 = res & X[rs2];
-	            MEM[offs] = res2;            
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res = MEM[offs];
+                if (rd != 0) X[rd] = res;
+                unsigned<XLEN> res2 = res & X[rs2];
+                MEM[offs] = res2;
             }
         }
+
         AMOORD {
             encoding: 0b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd] = res;
-	            unsigned<XLEN>  res2 = res :: X[rs2];
-	            MEM[offs] = res2;            
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res = MEM[offs];
+                if (rd != 0) X[rd] = res;
+                unsigned<XLEN> res2 = res :: X[rs2];
+                MEM[offs] = res2;
             }
         }
-        AMOMIND{
+
+        AMOMIND {
             encoding: 0b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res1 = MEM[offs];
-	            if(rd!=0) X[rd] = res1;
-	            unsigned<XLEN>  res2 = res1 > (signed<XLEN> )X[rs2]? X[rs2] : res1;
-	            MEM[offs] = res2;
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res1 = MEM[offs];
+                if (rd != 0) X[rd] = res1;
+                unsigned<XLEN> res2 = res1 > (signed<XLEN> )X[rs2] ? X[rs2] : res1;
+                MEM[offs] = res2;
             }
         }
-        AMOMAXD{
+
+        AMOMAXD {
             encoding: 0b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            signed<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd] = res;
-	            unsigned<XLEN>  res2 = res < (signed<XLEN>)X[rs2]? X[rs2] : res;            
-	            MEM[offs] = res2;            
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                signed<XLEN> res = MEM[offs];
+                if (rd != 0) X[rd] = res;
+                unsigned<XLEN> res2 = res < (signed<XLEN>)X[rs2] ? X[rs2] : res;
+                MEM[offs] = res2;
             }
         }
-        AMOMINUD{
+
+        AMOMINUD {
             encoding: 0b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            unsigned<XLEN>  res = MEM[offs];
-	            if(rd!=0) X[rd] = res;
-	            unsigned<XLEN>  res2 = res > X[rs2]? X[rs2] : res;            
-	            MEM[offs] = res2;            
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                unsigned<XLEN> res = MEM[offs];
+                if (rd != 0) X[rd] = res;
+                unsigned<XLEN> res2 = res > X[rs2] ? X[rs2] : res;
+                MEM[offs] = res2;
             }
         }
-        AMOMAXUD{
+
+        AMOMAXUD {
             encoding: 0b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0101111;
-            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu={aq},rel={rl})";
-            behavior:  {
-	            unsigned<XLEN>  offs = X[rs1];
-	            unsigned<XLEN> res1 = MEM[offs];
-	            if(rd!=0) X[rd] = res1;
-	            unsigned<XLEN>  res2 = res1 < X[rs2]? X[rs2] : res1;
-	            MEM[offs] = res2;
+            args_disass: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            behavior: {
+                unsigned<XLEN> offs = X[rs1];
+                unsigned<XLEN> res1 = MEM[offs];
+                if (rd != 0) X[rd] = res1;
+                unsigned<XLEN> res2 = res1 < X[rs2] ? X[rs2] : res1;
+                MEM[offs] = res2;
             }
         }
     }

--- a/RVA.core_desc
+++ b/RVA.core_desc
@@ -5,9 +5,9 @@ InstructionSet RV32A extends RISCVBase {
         LRW {
             encoding: 5'b00010 :: aq[0:0] :: rl[0:0]  :: 5'b00000 :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(aq)}, {name(rl)}";
-            behavior: if (rd != 0) {
-                unsigned<XLEN> offs = X[rs1];
-                X[rd] = (signed<32>)MEM[offs];
+            behavior: if ((rd % RFS) != 0) {
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                X[rd % RFS] = (signed<XLEN>)((signed<32>)MEM[offs]);
                 RES[offs] = -1;
             }
         }
@@ -16,12 +16,12 @@ InstructionSet RV32A extends RISCVBase {
             encoding: 5'b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}, {name(aq)}, {name(rl)}";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
+                unsigned<XLEN> offs = X[rs1 % RFS];
                 unsigned<32> res1 = RES[offs];
                 if (res1 != 0)
-                    MEM[offs] = X[rs2];
-                if (rd != 0)
-                    X[rd] = res1 ? 0 : 1;
+                    MEM[offs] = X[rs2 % RFS];
+                if ((rd % RFS) != 0)
+                    X[rd % RFS] = res1 ? 0 : 1;
             }
         }
 
@@ -29,9 +29,9 @@ InstructionSet RV32A extends RISCVBase {
             encoding: 5'b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
-                if (rd != 0) X[rd] = (signed<32>)MEM[offs];
-                MEM[offs] = X[rs2];
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                if ((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)((signed<32>)MEM[offs]);
+                MEM[offs] = (signed<32>)X[rs2 % RFS];
             }
         }
 
@@ -39,10 +39,10 @@ InstructionSet RV32A extends RISCVBase {
             encoding: 5'b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
+                unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
-                if (rd != 0) X[rd] = res1;
-                unsigned<32> res2 = res1 + X[rs2];
+                if ((rd % RFS) != 0) X[rd % RFS] = res1;
+                unsigned<32> res2 = res1 + X[rs2 % RFS];
                 MEM[offs] = res2;
             }
         }
@@ -51,10 +51,10 @@ InstructionSet RV32A extends RISCVBase {
             encoding: 5'b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
+                unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
-                if (rd != 0) X[rd] = res1;
-                unsigned<32> res2 = res1 ^ X[rs2];
+                if ((rd % RFS) != 0) X[rd % RFS] = res1;
+                unsigned<32> res2 = res1 ^ X[rs2 % RFS];
                 MEM[offs] = res2;
             }
         }
@@ -63,10 +63,10 @@ InstructionSet RV32A extends RISCVBase {
             encoding: 5'b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
+                unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
-                if (rd != 0) X[rd] = res1;
-                unsigned<32> res2 = res1 & X[rs2];
+                if ((rd % RFS) != 0) X[rd % RFS] = res1;
+                unsigned<32> res2 = res1 & X[rs2 % RFS];
                 MEM[offs] = res2;
             }
         }
@@ -75,10 +75,10 @@ InstructionSet RV32A extends RISCVBase {
             encoding: 5'b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
+                unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
-                if (rd != 0) X[rd] = res1;
-                unsigned<32> res2 = res1 | X[rs2];
+                if ((rd % RFS) != 0) X[rd % RFS] = res1;
+                unsigned<32> res2 = res1 | X[rs2 % RFS];
                 MEM[offs] = res2;
             }
         }
@@ -87,10 +87,10 @@ InstructionSet RV32A extends RISCVBase {
             encoding: 5'b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
+                unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
-                if (rd != 0) X[rd] = res1;
-                unsigned<32> res2 = res1 > (signed<32>)X[rs2] ? X[rs2] : res1;
+                if ((rd % RFS) != 0) X[rd % RFS] = res1;
+                unsigned<32> res2 = res1 > (signed<32>)X[rs2 % RFS] ? X[rs2 % RFS] : res1;
                 MEM[offs] = res2;
             }
         }
@@ -99,10 +99,10 @@ InstructionSet RV32A extends RISCVBase {
             encoding: 5'b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
+                unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
-                if (rd != 0) X[rd] = res1;
-                unsigned<32> res2 = res1 < (signed<32>)X[rs2] ? X[rs2] : res1;
+                if ((rd % RFS) != 0) X[rd % RFS] = res1;
+                unsigned<32> res2 = res1 < (signed<32>)X[rs2 % RFS] ? X[rs2 % RFS] : res1;
                 MEM[offs] = res2;
             }
         }
@@ -111,10 +111,10 @@ InstructionSet RV32A extends RISCVBase {
             encoding: 5'b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
+                unsigned<XLEN> offs = X[rs1 % RFS];
                 unsigned<32> res1 = MEM[offs];
-                if (rd != 0) X[rd] = (signed<32>)res1;
-                unsigned<32> res2 = res1 > X[rs2] ? X[rs2] : res1;
+                if ((rd % RFS) != 0) X[rd % RFS] = (signed<32>)res1;
+                unsigned<32> res2 = res1 > X[rs2 % RFS] ? X[rs2 % RFS] : res1;
                 MEM[offs] = res2;
             }
         }
@@ -123,10 +123,10 @@ InstructionSet RV32A extends RISCVBase {
             encoding: 5'b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
+                unsigned<XLEN> offs = X[rs1 % RFS];
                 unsigned<32> res1 = MEM[offs];
-                if (rd != 0) X[rd] = (signed<32>)res1;
-                unsigned<32> res2 = res1 < X[rs2] ? X[rs2] : res1;
+                if ((rd % RFS) != 0) X[rd % RFS] = (signed<32>)res1;
+                unsigned<32> res2 = res1 < X[rs2 % RFS] ? X[rs2 % RFS] : res1;
                 MEM[offs] = res2;
             }
         }

--- a/RVA.core_desc
+++ b/RVA.core_desc
@@ -139,9 +139,9 @@ InstructionSet RV64A extends RV32A {
             encoding: 5'b00010 :: aq[0:0] :: rl[0:0]  :: 5'b00000 :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}";
             behavior: {
-                if (rd != 0) {
-                    unsigned<XLEN> offs = X[rs1];
-                    X[rd] = (signed<XLEN>)MEM[offs];
+                if ((rd % RFS) != 0) {
+                    unsigned<XLEN> offs = X[rs1 % RFS];
+                    X[rd % RFS] = (signed<XLEN>)((signed<64>)MEM[offs]);
                     RES[offs] = -1;
                 }
             }
@@ -151,14 +151,12 @@ InstructionSet RV64A extends RV32A {
             encoding: 5'b00011 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-            unsigned<XLEN> offs = X[rs1];
-            unsigned<XLEN> res[64] = RES[offs];
-                if (res != 0) {
-                    MEM[offs] = X[rs2];
-                    if (rd != 0) X[rd] = 0;
-                } else {
-                    if (rd != 0) X[rd] = 1;
-                }
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                unsigned<64> res = RES[offs];
+                if (res != 0)
+                    MEM[offs] = X[rs2 % RFS];
+                if ((rd % RFS) != 0)
+                    X[rd % RFS] = res1 ? 0 : 1;
             }
         }
 
@@ -166,9 +164,9 @@ InstructionSet RV64A extends RV32A {
             encoding: 5'b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
-                if (rd != 0) X[rd] = MEM[offs];
-                MEM[offs] = X[rs2];
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                if ((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)((signed<64>)MEM[offs]);
+                MEM[offs] = (signed<64>)X[rs2 % RFS];
             }
         }
 
@@ -176,10 +174,10 @@ InstructionSet RV64A extends RV32A {
             encoding: 5'b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res = MEM[offs];
-                if (rd != 0) X[rd] = res;
-                unsigned<XLEN> res2 = res + X[rs2];
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                signed<64> res = MEM[offs];
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
+                unsigned<64> res2 = res + X[rs2 % RFS];
                 MEM[offs] = res2;
             }
         }
@@ -188,10 +186,10 @@ InstructionSet RV64A extends RV32A {
             encoding: 5'b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res = MEM[offs];
-                if (rd != 0) X[rd] = res;
-                unsigned<XLEN> res2 = res ^ X[rs2];
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                signed<64> res = MEM[offs];
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
+                unsigned<64> res2 = res ^ X[rs2 % RFS];
                 MEM[offs] = res2;
             }
         }
@@ -200,10 +198,10 @@ InstructionSet RV64A extends RV32A {
             encoding: 5'b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res = MEM[offs];
-                if (rd != 0) X[rd] = res;
-                unsigned<XLEN> res2 = res & X[rs2];
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                signed<64> res = MEM[offs];
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
+                unsigned<64> res2 = res & X[rs2 % RFS];
                 MEM[offs] = res2;
             }
         }
@@ -212,10 +210,10 @@ InstructionSet RV64A extends RV32A {
             encoding: 5'b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res = MEM[offs];
-                if (rd != 0) X[rd] = res;
-                unsigned<XLEN> res2 = res :: X[rs2];
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                signed<64> res = MEM[offs];
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
+                unsigned<64> res2 = res :: X[rs2 % RFS];
                 MEM[offs] = res2;
             }
         }
@@ -224,10 +222,10 @@ InstructionSet RV64A extends RV32A {
             encoding: 5'b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res1 = MEM[offs];
-                if (rd != 0) X[rd] = res1;
-                unsigned<XLEN> res2 = res1 > (signed<XLEN> )X[rs2] ? X[rs2] : res1;
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                signed<64> res1 = MEM[offs];
+                if ((rd % RFS) != 0) X[rd % RFS] = res1;
+                unsigned<64> res2 = res1 > (signed<64>)X[rs2 % RFS] ? X[rs2 % RFS] : res1;
                 MEM[offs] = res2;
             }
         }
@@ -236,10 +234,10 @@ InstructionSet RV64A extends RV32A {
             encoding: 5'b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
-                signed<XLEN> res = MEM[offs];
-                if (rd != 0) X[rd] = res;
-                unsigned<XLEN> res2 = res < (signed<XLEN>)X[rs2] ? X[rs2] : res;
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                signed<64> res = MEM[offs];
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
+                unsigned<64> res2 = res < (signed<64>)X[rs2 % RFS] ? X[rs2 % RFS] : res;
                 MEM[offs] = res2;
             }
         }
@@ -248,10 +246,10 @@ InstructionSet RV64A extends RV32A {
             encoding: 5'b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
-                unsigned<XLEN> res = MEM[offs];
-                if (rd != 0) X[rd] = res;
-                unsigned<XLEN> res2 = res > X[rs2] ? X[rs2] : res;
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                unsigned<64> res = MEM[offs];
+                if ((rd % RFS) != 0) X[rd % RFS] = (signed<64>)res;
+                unsigned<64> res2 = res > X[rs2 % RFS] ? X[rs2 % RFS] : res;
                 MEM[offs] = res2;
             }
         }
@@ -260,10 +258,10 @@ InstructionSet RV64A extends RV32A {
             encoding: 5'b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
             assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1];
-                unsigned<XLEN> res1 = MEM[offs];
-                if (rd != 0) X[rd] = res1;
-                unsigned<XLEN> res2 = res1 < X[rs2] ? X[rs2] : res1;
+                unsigned<XLEN> offs = X[rs1 % RFS];
+                unsigned<64> res1 = MEM[offs];
+                if ((rd % RFS) != 0) X[rd % RFS] = (signed<64>)res1;
+                unsigned<64> res2 = res1 < X[rs2 % RFS] ? X[rs2 % RFS] : res1;
                 MEM[offs] = res2;
             }
         }

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -8,7 +8,7 @@ InstructionSet RV32IC extends RV32I {
     instructions{
         CADDI4SPN { //(RES, imm=0)
             encoding: 0b000 :: imm[5:4] :: imm[9:6] :: imm[2:2] :: imm[3:3] :: rd[2:0] :: 0b00;
-            args_disass: "{name(rd)}, {imm:#05x}";
+            assembly: "{name(rd)}, {imm:#05x}";
             behavior:
                 if (imm) X[rd + 8] = X[2] + imm;
                 else raise(0, 2);
@@ -16,7 +16,7 @@ InstructionSet RV32IC extends RV32I {
 
         CLW { // (RV32)
             encoding: 0b010 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 0b00;
-            args_disass: "{name(8+rd)}, {uimm:#05x}({name(8+rs1)})";
+            assembly: "{name(8+rd)}, {uimm:#05x}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1 + 8] + uimm;
                 X[rd + 8] = (signed<32>)MEM[load_address];
@@ -25,7 +25,7 @@ InstructionSet RV32IC extends RV32I {
 
         CSW {//(RV32)
             encoding: 0b110 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 0b00;
-            args_disass: "{name(8+rs2)}, {uimm:#05x}({name(8+rs1)})";
+            assembly: "{name(8+rs2)}, {uimm:#05x}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1 + 8] + uimm;
                 MEM[load_address] = (signed<32>)X[rs2 + 8];
@@ -34,7 +34,7 @@ InstructionSet RV32IC extends RV32I {
 
         CADDI {//(RV32)
             encoding: 0b000 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 0b01;
-            args_disass: "{name(rs1)}, {imm:#05x}";
+            assembly: "{name(rs1)}, {imm:#05x}";
             behavior: X[rs1] = X[rs1] + (signed<6>)imm;
         }
 
@@ -48,7 +48,7 @@ InstructionSet RV32IC extends RV32I {
         // CJAL will be overwritten by CADDIW for RV64/128
         CJAL [[no_cont]] {//(RV32)
             encoding: 0b001 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 0b01;
-            args_disass: "{imm:#05x}";
+            assembly: "{imm:#05x}";
             behavior: {
                 X[1] = PC + 2;
                 PC = PC + (signed<12>)imm;
@@ -57,7 +57,7 @@ InstructionSet RV32IC extends RV32I {
 
         CLI {//(RV32)
             encoding: 0b010 :: imm[5:5] :: rd[4:0] :: imm[4:0] :: 0b01;
-            args_disass: "{name(rd)}, {imm:#05x}";
+            assembly: "{name(rd)}, {imm:#05x}";
             behavior: {
                 if (rd != 0) X[rd] = (signed<6>)imm;
             }
@@ -66,7 +66,7 @@ InstructionSet RV32IC extends RV32I {
         // order matters here as CADDI16SP overwrites CLUI for rd == 2
         CLUI {//(RV32)
             encoding: 0b011 :: imm[17:17] :: rd[4:0] :: imm[16:12] :: 0b01;
-            args_disass: "{name(rd)}, {imm:#05x}";
+            assembly: "{name(rd)}, {imm:#05x}";
             behavior: {
                 if (imm == 0) raise(0, 2);
                 if (rd != 0) X[rd] = (signed<18>)imm;
@@ -75,7 +75,7 @@ InstructionSet RV32IC extends RV32I {
 
         CADDI16SP {//(RV32)
             encoding: 0b011 :: nzimm[9:9] :: 0b00010 :: nzimm[4:4] :: nzimm[6:6] :: nzimm[8:7] :: nzimm[5:5] :: 0b01;
-            args_disass: "{nzimm:#05x}";
+            assembly: "{nzimm:#05x}";
             behavior:
                 if (nzimm) X[2] = X[2] + (signed<10>)nzimm;
                 else raise(0, 2);
@@ -88,7 +88,7 @@ InstructionSet RV32IC extends RV32I {
 
         CSRLI {//(RV32 nse)
             encoding: 0b100 :: 0b0 :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            assembly: "{name(8+rs1)}, {shamt}";
             behavior: {
                 unsigned<32> rs1_idx = rs1 + 8;
                 X[rs1_idx] = X[rs1_idx] >> shamt;
@@ -97,7 +97,7 @@ InstructionSet RV32IC extends RV32I {
 
         CSRAI {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            assembly: "{name(8+rs1)}, {shamt}";
             behavior: {
                 unsigned<32> rs1_idx = rs1+8;
                 if (shamt) {
@@ -110,7 +110,7 @@ InstructionSet RV32IC extends RV32I {
 
         CANDI {//(RV32)
             encoding: 0b100 :: imm[5:5] :: 0b10 :: rs1[2:0] :: imm[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {imm:#05x}";
+            assembly: "{name(8+rs1)}, {imm:#05x}";
             behavior: {
                 unsigned<32> rs1_idx = rs1 + 8;
                 X[rs1_idx] = X[rs1_idx] & (signed<6>)imm;
@@ -119,7 +119,7 @@ InstructionSet RV32IC extends RV32I {
 
         CSUB {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b00 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rs2)}";
+            assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned<32> rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] - X[rs2 + 8];
@@ -128,7 +128,7 @@ InstructionSet RV32IC extends RV32I {
 
         CXOR {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b01 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rs2)}";
+            assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned<32> rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] ^ X[rs2 + 8];
@@ -137,7 +137,7 @@ InstructionSet RV32IC extends RV32I {
 
         COR {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b10 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rs2)}";
+            assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned<32> rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] | X[rs2 + 8];
@@ -146,7 +146,7 @@ InstructionSet RV32IC extends RV32I {
 
         CAND {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b11 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rs2)}";
+            assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned<32> rd_idx = rd + 8;
                 X[rd_idx] = X[rd_idx] & X[rs2 + 8];
@@ -155,31 +155,31 @@ InstructionSet RV32IC extends RV32I {
 
         CJ [[no_cont]] {//(RV32)
             encoding: 0b101 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 0b01;
-            args_disass: "{imm:#05x}";
+            assembly: "{imm:#05x}";
             behavior: PC = PC + (signed<12>)imm;
         }
 
         CBEQZ [[no_cont]] [[cond]] {//(RV32)
             encoding: 0b110 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 0b01;
-            args_disass: "{name(8+rs1)}, {imm:#05x}";
+            assembly: "{name(8+rs1)}, {imm:#05x}";
             behavior: if (X[rs1 + 8] == 0) PC = PC + (signed<9>)imm;
         }
 
         CBNEZ [[no_cont]] [[cond]] {//(RV32)
             encoding: 0b111 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 0b01;
-            args_disass: "{name(8+rs1)}, {imm:#05x}";
+            assembly: "{name(8+rs1)}, {imm:#05x}";
             behavior: if (X[rs1+8] != 0) PC = PC + (signed<9>)imm;
         }
 
         CSLLI {//(RV32)
             encoding: 0b000 :: 0b0 :: rs1[4:0] :: nzuimm[4:0] :: 0b10;
-            args_disass: "{name(rs1)}, {nzuimm}";
+            assembly: "{name(rs1)}, {nzuimm}";
             behavior: if (nzuimm) X[rs1] = X[rs1]<< nzuimm;
         }
 
         CLWSP {//
             encoding: 0b010 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 0b10;
-            args_disass: "{name(rd)}, sp, {uimm:#05x}";
+            assembly: "{name(rd)}, sp, {uimm:#05x}";
             behavior: {
                 if (rd) {
                     unsigned<XLEN> offs = X[2] + uimm;
@@ -193,13 +193,13 @@ InstructionSet RV32IC extends RV32I {
         // order matters as CJR is a special case of CMV
         CMV {//(RV32)
             encoding: 0b100 :: 0b0 :: rd[4:0] :: rs2[4:0] :: 0b10;
-            args_disass: "{name(rd)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs2];
         }
 
         CJR [[no_cont]] {//(RV32)
             encoding: 0b100 :: 0b0 :: rs1[4:0] :: 0b00000 :: 0b10;
-            args_disass: "{name(rs1)}";
+            assembly: "{name(rs1)}";
             behavior: if (rs1)
                 PC = X[rs1] & ~0x1;
             else
@@ -214,13 +214,13 @@ InstructionSet RV32IC extends RV32I {
         // order matters as CEBREAK is a special case of CJALR which is a special case of CADD
         CADD {//(RV32)
             encoding: 0b100 :: 0b1 :: rd[4:0] :: rs2[4:0] :: 0b10;
-            args_disass: "{name(rd)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rd] + X[rs2];
         }
 
         CJALR [[no_cont]] {//(RV32)
             encoding: 0b100 :: 0b1 :: rs1[4:0] :: 0b00000 :: 0b10;
-            args_disass: "{name(rs1)}";
+            assembly: "{name(rs1)}";
             behavior: {
                 unsigned<XLEN> new_pc = X[rs1];
                 X[1] = PC + 2;
@@ -235,7 +235,7 @@ InstructionSet RV32IC extends RV32I {
 
         CSWSP {//
             encoding: 0b110 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 0b10;
-            args_disass: "{name(rs2)}, {uimm:#05x}(sp)";
+            assembly: "{name(rs2)}, {uimm:#05x}(sp)";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<32>)X[rs2];
@@ -253,7 +253,7 @@ InstructionSet RV32FC extends RV32F {
     instructions {
         CFLW {
             encoding: 0b011 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 0b00;
-            args_disass:"f(8+{rd}), {uimm}({name(8+rs1)})";
+            assembly:"f(8+{rd}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1+8]+uimm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -267,7 +267,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFSW {
             encoding: 0b111 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 0b00;
-            args_disass:"f(8+{rs2}), {uimm}({name(8+rs1)})";
+            assembly:"f(8+{rs2}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 MEM[offs] = (unsigned<32>)F[rs2 + 8];
@@ -276,7 +276,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFLWSP {
             encoding: 0b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 0b10;
-            args_disass:"f {rd}, {uimm}(x2)";
+            assembly:"f {rd}, {uimm}(x2)";
             behavior: {
                 unsigned<XLEN> offs = X[2]+uimm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -290,7 +290,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFSWSP {
             encoding: 0b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 0b10;
-            args_disass:"f {rs2}, {uimm}(x2), ";
+            assembly:"f {rs2}, {uimm}(x2), ";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<32>)F[rs2];
@@ -303,7 +303,7 @@ InstructionSet RV32DC extends RV32D {
     instructions {
         CFLD { //(RV32/64)
             encoding: 0b001 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
-            args_disass:"f(8+{rd}), {uimm}({name(8+rs1)})";
+            assembly:"f(8+{rd}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
@@ -317,7 +317,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFSD { //(RV32/64)
             encoding: 0b101 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
-            args_disass:"f(8+{rs2}), {uimm}({name(8+rs1)})";
+            assembly:"f(8+{rs2}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 MEM[offs] = (unsigned<64>)F[rs2 + 8];
@@ -326,7 +326,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFLDSP {//(RV32/64)
             encoding: 0b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
-            args_disass:"f {rd}, {uimm}(x2)";
+            assembly:"f {rd}, {uimm}(x2)";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
@@ -340,7 +340,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFSDSP {//(RV32/64)
             encoding: 0b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 0b10;
-            args_disass:"f {rs2}, {uimm}(x2), ";
+            assembly:"f {rs2}, {uimm}(x2), ";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<64>)F[rs2];
@@ -355,31 +355,31 @@ InstructionSet RV64IC extends RV32IC {
     instructions {
         CLD {//(RV64/128)
             encoding:b011 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
-            args_disass: "{name(8+rd)}, {uimm},({name(8+rs1)})";
+            assembly: "{name(8+rd)}, {uimm},({name(8+rs1)})";
             unsigned<XLEN> offs = X[rs1+8] + uimm;
             X[rd+8] = (signed<64>)MEM[offs];
         }
         CSD { //(RV64/128)
             encoding:b111 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
-            args_disass: "{name(8+rs2)}, {uimm},({name(8+rs1)})";
+            assembly: "{name(8+rs2)}, {uimm},({name(8+rs1)})";
             unsigned<XLEN> offs = X[rs1+8] + uimm;
             MEM[offs] = (signed<64>)X[rs2+8];
         }
         CSUBW {//(RV64/128, RV32 res)
             encoding:b100 :: 0b1 :: 0b11 :: rd[2:0] :: 0b00 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
+            assembly: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
             unsigned<32> res = (unsigned<32>)X[rd+8] - (unsigned<32>)X[rs2+8];
             X[rd+8] = (signed)res;
         }
         CADDW {//(RV64/128 RV32 res)
             encoding:b100 :: 0b1 :: 0b11 :: rd[2:0] :: 0b01 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
+            assembly: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
             unsigned<32> res = (unsigned<32>)X[rd+8] + (unsigned<32>)X[rs2+8];
             X[rd+8] = (signed)res;
         }
         CADDIW {//(RV64/128)
             encoding:b001 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 0b01;
-            args_disass: "{name(rs1)}, {imm:#05x}";
+            assembly: "{name(rs1)}, {imm:#05x}";
             if (rs1 != 0) {
                 unsigned<32> res = (signed)X[rs1] + (signed)imm;
                 X[rs1] = (signed)res;
@@ -387,37 +387,37 @@ InstructionSet RV64IC extends RV32IC {
         }
         CSRLI {//(RV64)
             encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            assembly: "{name(8+rs1)}, {shamt}";
             val rs1_idx[5] = rs1+8;
             X[rs1_idx] = shrl(X[rs1_idx], shamt);
         }
         CSRLI64 {//(RV64)
             encoding:b1000 :: 0b00 :: rs1[2:0] :: 00000 :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            assembly: "{name(8+rs1)}, {shamt}";
             val rs1_idx[5] = rs1+8;
             X[rs1_idx] = shrl(X[rs1_idx], shamt);
         }
         CSRAI {//(RV64)
             encoding:b100 :: shamt[5:5] :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            assembly: "{name(8+rs1)}, {shamt}";
             val rs1_idx[5] = rs1+8;
             X[rs1_idx] = shra(X[rs1_idx], shamt);
         }
         CSLLI {//(RV64)
             encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 0b10;
-            args_disass: "{name(rs1)}, {shamt}";
+            assembly: "{name(rs1)}, {shamt}";
             if (rs1 == 0) raise(0, 2);
             X[rs1] = shll(X[rs1], shamt);
         }
         CLDSP {//(RV64/128
             encoding:b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
-            args_disass:"{name(rd)}, {uimm}(sp)";
+            assembly:"{name(rd)}, {uimm}(sp)";
             unsigned<XLEN> offs = X[2] + uimm;
             if (rd != 0) X[rd] = sext(MEM[offs]{64});
         }
         CSDSP {//(RV64/128)
             encoding:b111 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 0b10;
-            args_disass:"{name(rs2)}, {uimm}(sp)";
+            assembly:"{name(rs2)}, {uimm}(sp)";
             unsigned<XLEN> offs = X[2] + uimm;
             MEM[offs]{64} = X[rs2];
         }
@@ -429,19 +429,19 @@ InstructionSet RV128IC extends RV64IC {
     instructions {
         CSRLI {//(RV128)
             encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            assembly: "{name(8+rs1)}, {shamt}";
             val rs1_idx[5] = rs1+8;
             X[rs1_idx] = shrl(X[rs1_idx], shamt);
         }
         CSRAI {//(RV128)
             encoding:b100 :: shamt[5:5] :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            args_disass: "{name(8+rs1)}, {shamt}";
+            assembly: "{name(8+rs1)}, {shamt}";
             val rs1_idx[5] = rs1+8;
             X[rs1_idx] = shra(X[rs1_idx], shamt);
         }
         CSLLI {//(RV128)
             encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 0b10;
-            args_disass: "{name(rs1)}, {shamt}";
+            assembly: "{name(rs1)}, {shamt}";
             if (rs1 == 0) raise(0, 2);
             X[rs1] = shll(X[rs1], shamt);
         }

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -7,7 +7,7 @@ InstructionSet RV32IC extends RV32I {
 
     instructions{
         CADDI4SPN { //(RES, imm=0)
-            encoding: 0b000 :: imm[5:4] :: imm[9:6] :: imm[2:2] :: imm[3:3] :: rd[2:0] :: 0b00;
+            encoding: 3'b000 :: imm[5:4] :: imm[9:6] :: imm[2:2] :: imm[3:3] :: rd[2:0] :: 2'b00;
             assembly: "{name(rd)}, {imm:#05x}";
             behavior:
                 if (imm) X[rd + 8] = X[2] + imm;
@@ -15,7 +15,7 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CLW { // (RV32)
-            encoding: 0b010 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 0b00;
+            encoding: 3'b010 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 2'b00;
             assembly: "{name(8+rd)}, {uimm:#05x}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1 + 8] + uimm;
@@ -24,7 +24,7 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CSW {//(RV32)
-            encoding: 0b110 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 0b00;
+            encoding: 3'b110 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 2'b00;
             assembly: "{name(8+rs2)}, {uimm:#05x}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1 + 8] + uimm;
@@ -33,13 +33,13 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CADDI {//(RV32)
-            encoding: 0b000 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 0b01;
+            encoding: 3'b000 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 2'b01;
             assembly: "{name(rs1)}, {imm:#05x}";
             behavior: X[rs1] = X[rs1] + (signed<6>)imm;
         }
 
         CNOP {
-            encoding: 0b000 :: nzimm[5:5] :: 0b00000 :: nzimm[4:0] :: 0b01;
+            encoding: 3'b000 :: nzimm[5:5] :: 5'b00000 :: nzimm[4:0] :: 2'b01;
             behavior: {
                 //if (!nzimm) raise(0, 2);
             }
@@ -47,7 +47,7 @@ InstructionSet RV32IC extends RV32I {
 
         // CJAL will be overwritten by CADDIW for RV64/128
         CJAL [[no_cont]] {//(RV32)
-            encoding: 0b001 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 0b01;
+            encoding: 3'b001 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 2'b01;
             assembly: "{imm:#05x}";
             behavior: {
                 X[1] = PC + 2;
@@ -56,7 +56,7 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CLI {//(RV32)
-            encoding: 0b010 :: imm[5:5] :: rd[4:0] :: imm[4:0] :: 0b01;
+            encoding: 3'b010 :: imm[5:5] :: rd[4:0] :: imm[4:0] :: 2'b01;
             assembly: "{name(rd)}, {imm:#05x}";
             behavior: {
                 if (rd != 0) X[rd] = (signed<6>)imm;
@@ -65,7 +65,7 @@ InstructionSet RV32IC extends RV32I {
 
         // order matters here as CADDI16SP overwrites CLUI for rd == 2
         CLUI {//(RV32)
-            encoding: 0b011 :: imm[17:17] :: rd[4:0] :: imm[16:12] :: 0b01;
+            encoding: 3'b011 :: imm[17:17] :: rd[4:0] :: imm[16:12] :: 2'b01;
             assembly: "{name(rd)}, {imm:#05x}";
             behavior: {
                 if (imm == 0) raise(0, 2);
@@ -74,7 +74,7 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CADDI16SP {//(RV32)
-            encoding: 0b011 :: nzimm[9:9] :: 0b00010 :: nzimm[4:4] :: nzimm[6:6] :: nzimm[8:7] :: nzimm[5:5] :: 0b01;
+            encoding: 3'b011 :: nzimm[9:9] :: 5'b00010 :: nzimm[4:4] :: nzimm[6:6] :: nzimm[8:7] :: nzimm[5:5] :: 2'b01;
             assembly: "{nzimm:#05x}";
             behavior:
                 if (nzimm) X[2] = X[2] + (signed<10>)nzimm;
@@ -82,12 +82,12 @@ InstructionSet RV32IC extends RV32I {
         }
 
         __reserved_clui {//(RV32)
-            encoding: 0b011 :: 0b0 :: rd[4:0] :: 0b00000 :: 0b01;
+            encoding: 3'b011 :: 1'b0 :: rd[4:0] :: 5'b00000 :: 2'b01;
             behavior: raise(0, 2);
         }
 
         CSRLI {//(RV32 nse)
-            encoding: 0b100 :: 0b0 :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
+            encoding: 3'b100 :: 1'b0 :: 2'b00 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
             assembly: "{name(8+rs1)}, {shamt}";
             behavior: {
                 unsigned<32> rs1_idx = rs1 + 8;
@@ -96,7 +96,7 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CSRAI {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
+            encoding: 3'b100 :: 1'b0 :: 2'b01 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
             assembly: "{name(8+rs1)}, {shamt}";
             behavior: {
                 unsigned<32> rs1_idx = rs1+8;
@@ -109,7 +109,7 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CANDI {//(RV32)
-            encoding: 0b100 :: imm[5:5] :: 0b10 :: rs1[2:0] :: imm[4:0] :: 0b01;
+            encoding: 3'b100 :: imm[5:5] :: 2'b10 :: rs1[2:0] :: imm[4:0] :: 2'b01;
             assembly: "{name(8+rs1)}, {imm:#05x}";
             behavior: {
                 unsigned<32> rs1_idx = rs1 + 8;
@@ -118,7 +118,7 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CSUB {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b00 :: rs2[2:0] :: 0b01;
+            encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b00 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned<32> rd_idx = rd + 8;
@@ -127,7 +127,7 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CXOR {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b01 :: rs2[2:0] :: 0b01;
+            encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b01 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned<32> rd_idx = rd + 8;
@@ -136,7 +136,7 @@ InstructionSet RV32IC extends RV32I {
         }
 
         COR {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b10 :: rs2[2:0] :: 0b01;
+            encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b10 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned<32> rd_idx = rd + 8;
@@ -145,7 +145,7 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CAND {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b11 :: rs2[2:0] :: 0b01;
+            encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b11 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
                 unsigned<32> rd_idx = rd + 8;
@@ -154,31 +154,31 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CJ [[no_cont]] {//(RV32)
-            encoding: 0b101 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 0b01;
+            encoding: 3'b101 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 2'b01;
             assembly: "{imm:#05x}";
             behavior: PC = PC + (signed<12>)imm;
         }
 
         CBEQZ [[no_cont]] [[cond]] {//(RV32)
-            encoding: 0b110 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 0b01;
+            encoding: 3'b110 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 2'b01;
             assembly: "{name(8+rs1)}, {imm:#05x}";
             behavior: if (X[rs1 + 8] == 0) PC = PC + (signed<9>)imm;
         }
 
         CBNEZ [[no_cont]] [[cond]] {//(RV32)
-            encoding: 0b111 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 0b01;
+            encoding: 3'b111 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 2'b01;
             assembly: "{name(8+rs1)}, {imm:#05x}";
             behavior: if (X[rs1+8] != 0) PC = PC + (signed<9>)imm;
         }
 
         CSLLI {//(RV32)
-            encoding: 0b000 :: 0b0 :: rs1[4:0] :: nzuimm[4:0] :: 0b10;
+            encoding: 3'b000 :: 1'b0 :: rs1[4:0] :: nzuimm[4:0] :: 2'b10;
             assembly: "{name(rs1)}, {nzuimm}";
             behavior: if (nzuimm) X[rs1] = X[rs1]<< nzuimm;
         }
 
         CLWSP {//
-            encoding: 0b010 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 0b10;
+            encoding: 3'b010 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 2'b10;
             assembly: "{name(rd)}, sp, {uimm:#05x}";
             behavior: {
                 if (rd) {
@@ -192,13 +192,13 @@ InstructionSet RV32IC extends RV32I {
 
         // order matters as CJR is a special case of CMV
         CMV {//(RV32)
-            encoding: 0b100 :: 0b0 :: rd[4:0] :: rs2[4:0] :: 0b10;
+            encoding: 3'b100 :: 1'b0 :: rd[4:0] :: rs2[4:0] :: 2'b10;
             assembly: "{name(rd)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rs2];
         }
 
         CJR [[no_cont]] {//(RV32)
-            encoding: 0b100 :: 0b0 :: rs1[4:0] :: 0b00000 :: 0b10;
+            encoding: 3'b100 :: 1'b0 :: rs1[4:0] :: 5'b00000 :: 2'b10;
             assembly: "{name(rs1)}";
             behavior: if (rs1)
                 PC = X[rs1] & ~0x1;
@@ -207,19 +207,19 @@ InstructionSet RV32IC extends RV32I {
         }
 
         __reserved_cmv {//(RV32)
-            encoding: 0b100 :: 0b0 :: 0b00000 :: 0b00000 :: 0b10;
+            encoding: 3'b100 :: 1'b0 :: 5'b00000 :: 5'b00000 :: 2'b10;
             behavior: raise(0,2);
         }
 
         // order matters as CEBREAK is a special case of CJALR which is a special case of CADD
         CADD {//(RV32)
-            encoding: 0b100 :: 0b1 :: rd[4:0] :: rs2[4:0] :: 0b10;
+            encoding: 3'b100 :: 1'b1 :: rd[4:0] :: rs2[4:0] :: 2'b10;
             assembly: "{name(rd)}, {name(rs2)}";
             behavior: if (rd != 0) X[rd] = X[rd] + X[rs2];
         }
 
         CJALR [[no_cont]] {//(RV32)
-            encoding: 0b100 :: 0b1 :: rs1[4:0] :: 0b00000 :: 0b10;
+            encoding: 3'b100 :: 1'b1 :: rs1[4:0] :: 5'b00000 :: 2'b10;
             assembly: "{name(rs1)}";
             behavior: {
                 unsigned<XLEN> new_pc = X[rs1];
@@ -229,12 +229,12 @@ InstructionSet RV32IC extends RV32I {
         }
 
         CEBREAK [[no_cont]] {//(RV32)
-            encoding: 0b100 :: 0b1 :: 0b00000 :: 0b00000 :: 0b10;
+            encoding: 3'b100 :: 1'b1 :: 5'b00000 :: 5'b00000 :: 2'b10;
             behavior: raise(0, 3);
         }
 
         CSWSP {//
-            encoding: 0b110 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 0b10;
+            encoding: 3'b110 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 2'b10;
             assembly: "{name(rs2)}, {uimm:#05x}(sp)";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
@@ -243,7 +243,7 @@ InstructionSet RV32IC extends RV32I {
         }
 
         DII [[no_cont]] { // Defined Illegal Instruction
-            encoding: 0b000 :: 0b0 :: 0b00000 :: 0b00000 :: 0b00;
+            encoding: 3'b000 :: 1'b0 :: 5'b00000 :: 5'b00000 :: 2'b00;
             behavior: raise(0, 2);
         }
     }
@@ -252,7 +252,7 @@ InstructionSet RV32IC extends RV32I {
 InstructionSet RV32FC extends RV32F {
     instructions {
         CFLW {
-            encoding: 0b011 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 0b00;
+            encoding: 3'b011 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 2'b00;
             assembly:"f(8+{rd}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1+8]+uimm;
@@ -266,7 +266,7 @@ InstructionSet RV32FC extends RV32F {
         }
 
         CFSW {
-            encoding: 0b111 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 0b00;
+            encoding: 3'b111 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 2'b00;
             assembly:"f(8+{rs2}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
@@ -275,7 +275,7 @@ InstructionSet RV32FC extends RV32F {
         }
 
         CFLWSP {
-            encoding: 0b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 0b10;
+            encoding: 3'b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 2'b10;
             assembly:"f {rd}, {uimm}(x2)";
             behavior: {
                 unsigned<XLEN> offs = X[2]+uimm;
@@ -289,7 +289,7 @@ InstructionSet RV32FC extends RV32F {
         }
 
         CFSWSP {
-            encoding: 0b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 0b10;
+            encoding: 3'b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 2'b10;
             assembly:"f {rs2}, {uimm}(x2), ";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
@@ -302,7 +302,7 @@ InstructionSet RV32FC extends RV32F {
 InstructionSet RV32DC extends RV32D {
     instructions {
         CFLD { //(RV32/64)
-            encoding: 0b001 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
+            encoding: 3'b001 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
             assembly:"f(8+{rd}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
@@ -316,7 +316,7 @@ InstructionSet RV32DC extends RV32D {
         }
 
         CFSD { //(RV32/64)
-            encoding: 0b101 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
+            encoding: 3'b101 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
             assembly:"f(8+{rs2}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
@@ -325,7 +325,7 @@ InstructionSet RV32DC extends RV32D {
         }
 
         CFLDSP {//(RV32/64)
-            encoding: 0b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
+            encoding: 3'b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 2'b10;
             assembly:"f {rd}, {uimm}(x2)";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
@@ -339,7 +339,7 @@ InstructionSet RV32DC extends RV32D {
         }
 
         CFSDSP {//(RV32/64)
-            encoding: 0b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 0b10;
+            encoding: 3'b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 2'b10;
             assembly:"f {rs2}, {uimm}(x2), ";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
@@ -354,31 +354,31 @@ InstructionSet RV64IC extends RV32IC {
 
     instructions {
         CLD {//(RV64/128)
-            encoding:b011 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
+            encoding: 3'b011:: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
             assembly: "{name(8+rd)}, {uimm},({name(8+rs1)})";
             unsigned<XLEN> offs = X[rs1+8] + uimm;
             X[rd+8] = (signed<64>)MEM[offs];
         }
         CSD { //(RV64/128)
-            encoding:b111 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
+            encoding: 3'b111:: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
             assembly: "{name(8+rs2)}, {uimm},({name(8+rs1)})";
             unsigned<XLEN> offs = X[rs1+8] + uimm;
             MEM[offs] = (signed<64>)X[rs2+8];
         }
         CSUBW {//(RV64/128, RV32 res)
-            encoding:b100 :: 0b1 :: 0b11 :: rd[2:0] :: 0b00 :: rs2[2:0] :: 0b01;
+            encoding: 3'b100 :: 0b1 :: 2'b11:: rd[2:0] :: 2'b00:: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
             unsigned<32> res = (unsigned<32>)X[rd+8] - (unsigned<32>)X[rs2+8];
             X[rd+8] = (signed)res;
         }
         CADDW {//(RV64/128 RV32 res)
-            encoding:b100 :: 0b1 :: 0b11 :: rd[2:0] :: 0b01 :: rs2[2:0] :: 0b01;
+            encoding: 3'b100 :: 0b1 :: 2'b11:: rd[2:0] :: 2'b01:: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
             unsigned<32> res = (unsigned<32>)X[rd+8] + (unsigned<32>)X[rs2+8];
             X[rd+8] = (signed)res;
         }
         CADDIW {//(RV64/128)
-            encoding:b001 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 0b01;
+            encoding: 3'b001 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 2'b01;
             assembly: "{name(rs1)}, {imm:#05x}";
             if (rs1 != 0) {
                 unsigned<32> res = (signed)X[rs1] + (signed)imm;
@@ -410,13 +410,13 @@ InstructionSet RV64IC extends RV32IC {
             X[rs1] = shll(X[rs1], shamt);
         }
         CLDSP {//(RV64/128
-            encoding:b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
+            encoding: 3'b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 2'b10;
             assembly:"{name(rd)}, {uimm}(sp)";
             unsigned<XLEN> offs = X[2] + uimm;
             if (rd != 0) X[rd] = sext(MEM[offs]{64});
         }
         CSDSP {//(RV64/128)
-            encoding:b111 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 0b10;
+            encoding: 3'b111 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 2'b10;
             assembly:"{name(rs2)}, {uimm}(sp)";
             unsigned<XLEN> offs = X[2] + uimm;
             MEM[offs]{64} = X[rs2];

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -59,7 +59,7 @@ InstructionSet RV32IC extends RV32I {
             encoding: 0b010 :: imm[5:5] :: rd[4:0] :: imm[4:0] :: 0b01;
             args_disass: "{name(rd)}, {imm:#05x}";
             behavior: {
-                if (rd != 0) X[rd] = (signed)imm;
+                if (rd != 0) X[rd] = (signed<6>)imm;
             }
         }
 

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -35,7 +35,7 @@ InstructionSet RV32IC extends RV32I {
         CADDI {//(RV32)
             encoding: 3'b000 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 2'b01;
             assembly: "{name(rs1)}, {imm:#05x}";
-            behavior: X[rs1] = X[rs1] + (signed<6>)imm;
+            behavior: if ((rs1 % RFS) != 0) X[rs1 % RFS] = X[rs1 % RFS] + (signed<6>)imm;
         }
 
         CNOP {
@@ -59,7 +59,7 @@ InstructionSet RV32IC extends RV32I {
             encoding: 3'b010 :: imm[5:5] :: rd[4:0] :: imm[4:0] :: 2'b01;
             assembly: "{name(rd)}, {imm:#05x}";
             behavior: {
-                if (rd != 0) X[rd] = (signed<6>)imm;
+                if ((rd % RFS) != 0) X[rd % RFS] = (signed<6>)imm;
             }
         }
 
@@ -69,7 +69,7 @@ InstructionSet RV32IC extends RV32I {
             assembly: "{name(rd)}, {imm:#05x}";
             behavior: {
                 if (imm == 0) raise(0, 2);
-                if (rd != 0) X[rd] = (signed<18>)imm;
+                if ((rd % RFS) != 0) X[rd % RFS] = (signed<18>)imm;
             }
         }
 
@@ -90,8 +90,7 @@ InstructionSet RV32IC extends RV32I {
             encoding: 3'b100 :: 1'b0 :: 2'b00 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
             assembly: "{name(8+rs1)}, {shamt}";
             behavior: {
-                unsigned<32> rs1_idx = rs1 + 8;
-                X[rs1_idx] = X[rs1_idx] >> shamt;
+                X[rs1 + 8] = X[rs1 + 8] >> shamt;
             }
         }
 
@@ -99,11 +98,10 @@ InstructionSet RV32IC extends RV32I {
             encoding: 3'b100 :: 1'b0 :: 2'b01 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
             assembly: "{name(8+rs1)}, {shamt}";
             behavior: {
-                unsigned<32> rs1_idx = rs1+8;
                 if (shamt) {
-                    X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> shamt;
+                    X[rs1 + 8] = ((signed<XLEN>)X[rs1 + 8]) >> shamt;
                 } else if (XLEN == 128) {
-                    X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> 64;
+                    X[rs1 + 8] = ((signed<XLEN>)X[rs1 + 8]) >> 64;
                 }
             }
         }
@@ -112,8 +110,7 @@ InstructionSet RV32IC extends RV32I {
             encoding: 3'b100 :: imm[5:5] :: 2'b10 :: rs1[2:0] :: imm[4:0] :: 2'b01;
             assembly: "{name(8+rs1)}, {imm:#05x}";
             behavior: {
-                unsigned<32> rs1_idx = rs1 + 8;
-                X[rs1_idx] = X[rs1_idx] & (signed<6>)imm;
+                X[rs1 + 8] = X[rs1 + 8] & (signed<6>)imm;
             }
         }
 
@@ -121,8 +118,7 @@ InstructionSet RV32IC extends RV32I {
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b00 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-                unsigned<32> rd_idx = rd + 8;
-                X[rd_idx] = X[rd_idx] - X[rs2 + 8];
+                X[rd + 8] = X[rd + 8] - X[rs2 + 8];
             }
         }
 
@@ -130,8 +126,7 @@ InstructionSet RV32IC extends RV32I {
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b01 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-                unsigned<32> rd_idx = rd + 8;
-                X[rd_idx] = X[rd_idx] ^ X[rs2 + 8];
+                X[rd + 8] = X[rd + 8] ^ X[rs2 + 8];
             }
         }
 
@@ -139,8 +134,7 @@ InstructionSet RV32IC extends RV32I {
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b10 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-                unsigned<32> rd_idx = rd + 8;
-                X[rd_idx] = X[rd_idx] | X[rs2 + 8];
+                X[rd + 8] = X[rd + 8] | X[rs2 + 8];
             }
         }
 
@@ -148,8 +142,7 @@ InstructionSet RV32IC extends RV32I {
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b11 :: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-                unsigned<32> rd_idx = rd + 8;
-                X[rd_idx] = X[rd_idx] & X[rs2 + 8];
+                X[rd + 8] = X[rd + 8] & X[rs2 + 8];
             }
         }
 
@@ -168,25 +161,26 @@ InstructionSet RV32IC extends RV32I {
         CBNEZ [[no_cont]] [[cond]] {//(RV32)
             encoding: 3'b111 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 2'b01;
             assembly: "{name(8+rs1)}, {imm:#05x}";
-            behavior: if (X[rs1+8] != 0) PC = PC + (signed<9>)imm;
+            behavior: if (X[rs1 + 8] != 0) PC = PC + (signed<9>)imm;
         }
 
         CSLLI {//(RV32)
             encoding: 3'b000 :: 1'b0 :: rs1[4:0] :: nzuimm[4:0] :: 2'b10;
             assembly: "{name(rs1)}, {nzuimm}";
-            behavior: if (nzuimm) X[rs1] = X[rs1]<< nzuimm;
+            behavior: if (nzuimm) X[rs1 % RFS] = X[rs1 % RFS] << nzuimm;
         }
 
         CLWSP {//
             encoding: 3'b010 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 2'b10;
             assembly: "{name(rd)}, sp, {uimm:#05x}";
             behavior: {
-                if (rd) {
-                    unsigned<XLEN> offs = X[2] + uimm;
-                    X[rd] = (signed<32>)MEM[offs];
-                } else {
+                unsigned<XLEN> offs = X[2] + uimm;
+                signed<32> res = MEM[offs];
+
+                if (rd % RFS)
+                    X[rd % RFS] = res;
+                else
                     raise(0,2);
-                }
             }
         }
 
@@ -194,14 +188,14 @@ InstructionSet RV32IC extends RV32I {
         CMV {//(RV32)
             encoding: 3'b100 :: 1'b0 :: rd[4:0] :: rs2[4:0] :: 2'b10;
             assembly: "{name(rd)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = X[rs2];
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rs2 % RFS];
         }
 
         CJR [[no_cont]] {//(RV32)
             encoding: 3'b100 :: 1'b0 :: rs1[4:0] :: 5'b00000 :: 2'b10;
             assembly: "{name(rs1)}";
             behavior: if (rs1)
-                PC = X[rs1] & ~0x1;
+                PC = X[rs1 % RFS] & ~0x1;
             else
                 raise(0,2);
         }
@@ -215,14 +209,14 @@ InstructionSet RV32IC extends RV32I {
         CADD {//(RV32)
             encoding: 3'b100 :: 1'b1 :: rd[4:0] :: rs2[4:0] :: 2'b10;
             assembly: "{name(rd)}, {name(rs2)}";
-            behavior: if (rd != 0) X[rd] = X[rd] + X[rs2];
+            behavior: if ((rd % RFS) != 0) X[rd % RFS] = X[rd % RFS] + X[rs2 % RFS];
         }
 
         CJALR [[no_cont]] {//(RV32)
             encoding: 3'b100 :: 1'b1 :: rs1[4:0] :: 5'b00000 :: 2'b10;
             assembly: "{name(rs1)}";
             behavior: {
-                unsigned<XLEN> new_pc = X[rs1];
+                unsigned<XLEN> new_pc = X[rs1 % RFS];
                 X[1] = PC + 2;
                 PC = new_pc & ~0x1;
             }
@@ -238,7 +232,7 @@ InstructionSet RV32IC extends RV32I {
             assembly: "{name(rs2)}, {uimm:#05x}(sp)";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
-                MEM[offs] = (unsigned<32>)X[rs2];
+                MEM[offs] = (unsigned<32>)X[rs2 % RFS];
             }
         }
 
@@ -255,12 +249,12 @@ InstructionSet RV32FC extends RV32F {
             encoding: 3'b011 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 2'b00;
             assembly:"f(8+{rd}), {uimm}({name(8+rs1)})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1+8]+uimm;
+                unsigned<XLEN> offs = X[rs1 + 8]+uimm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
                 if (FLEN == 32)
                     F[rd + 8] = res;
                 else { // NaN boxing
-                    F[rd + 8] = (-1 << 32) | res;
+                    F[rd + 8] = ((signed<FLEN>)-1 << 32) | res;
                 }
             }
         }
@@ -278,12 +272,12 @@ InstructionSet RV32FC extends RV32F {
             encoding: 3'b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 2'b10;
             assembly:"f {rd}, {uimm}(x2)";
             behavior: {
-                unsigned<XLEN> offs = X[2]+uimm;
+                unsigned<XLEN> offs = X[2] + uimm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
                 if (FLEN == 32)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1 << 32) | res;
+                    F[rd] = ((signed<FLEN>)-1 << 32) | res;
                 }
             }
         }
@@ -308,9 +302,9 @@ InstructionSet RV32DC extends RV32D {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
                 if (FLEN == 64)
-                    F[rd+8] = res;
+                    F[rd + 8] = res;
                 else { // NaN boxing
-                    F[rd+8] = (-1 << 64) | res;
+                    F[rd + 8] = (-1 << 64) | res;
                 }
             }
         }
@@ -349,111 +343,135 @@ InstructionSet RV32DC extends RV32D {
     }
 }
 
-/*
 InstructionSet RV64IC extends RV32IC {
+    instructions{
+        CSRLI {//(RV32/RV64)
+            encoding: 3'b100:: nzuimm[5:5] :: 2'b00:: rs1[2:0] :: nzuimm[4:0] :: 2'b01;
+            assembly: "{name(8+rs1)}, {nzuimm}";
+            behavior: {
+                X[rs1 + 8] = X[rs1 + 8] >> nzuimm;
+            }
+        }
 
-    instructions {
+        CSRAI {//(RV32/RV64)
+            encoding: 3'b100:: shamt[5:5] :: 2'b01:: rs1[2:0] :: shamt[4:0] :: 2'b01;
+            assembly: "{name(8+rs1)}, {shamt}";
+            behavior: {
+                X[rs1 + 8] = ((signed<XLEN>)X[rs1 + 8]) >> shamt;
+            }
+        }
+
+        CSLLI {//(RV32/RV64)
+            encoding: 3'b000:: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 2'b10;
+            assembly: "{name(rs1)}, {shamt}";
+            behavior: {
+                if(rs1 == 0) raise(0, 2);
+                X[rs1] = X[rs1] << shamt;
+            }
+        }
+
         CLD {//(RV64/128)
             encoding: 3'b011:: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
             assembly: "{name(8+rd)}, {uimm},({name(8+rs1)})";
-            unsigned<XLEN> offs = X[rs1+8] + uimm;
-            X[rd+8] = (signed<64>)MEM[offs];
+            behavior: {
+                unsigned<XLEN> offs = X[rs1 + 8] + uimm;
+                X[rd + 8] = (signed<64>)MEM[offs];
+            }
         }
+
         CSD { //(RV64/128)
             encoding: 3'b111:: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
             assembly: "{name(8+rs2)}, {uimm},({name(8+rs1)})";
-            unsigned<XLEN> offs = X[rs1+8] + uimm;
-            MEM[offs] = (signed<64>)X[rs2+8];
+            behavior: {
+                unsigned<XLEN> offs = X[rs1 + 8] + uimm;
+                MEM[offs]= (unsigned<64>)X[rs2 + 8];
+            }
         }
+
         CSUBW {//(RV64/128, RV32 res)
             encoding: 3'b100 :: 0b1 :: 2'b11:: rd[2:0] :: 2'b00:: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
-            unsigned<32> res = (unsigned<32>)X[rd+8] - (unsigned<32>)X[rs2+8];
-            X[rd+8] = (signed)res;
+            behavior: {
+                unsigned<32> res = (unsigned<32>)X[rd + 8] - (unsigned<32>)X[rs2 + 8];
+                X[rd + 8] = (signed<XLEN>)res;
+            }
         }
+
         CADDW {//(RV64/128 RV32 res)
             encoding: 3'b100 :: 0b1 :: 2'b11:: rd[2:0] :: 2'b01:: rs2[2:0] :: 2'b01;
             assembly: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
-            unsigned<32> res = (unsigned<32>)X[rd+8] + (unsigned<32>)X[rs2+8];
-            X[rd+8] = (signed)res;
+            behavior: {
+	            unsigned<32> res = (unsigned<32>)X[rd + 8] + (unsigned<32>)X[rs2 + 8];
+	            X[rd + 8] = (signed<XLEN>)res;
+            }
         }
+
         CADDIW {//(RV64/128)
             encoding: 3'b001 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 2'b01;
             assembly: "{name(rs1)}, {imm:#05x}";
-            if (rs1 != 0) {
-                unsigned<32> res = (signed)X[rs1] + (signed)imm;
-                X[rs1] = (signed)res;
-            }
+            behavior: if ((rs1 % RFS) != 0) X[rs1 % RFS] = (signed<32>)X[rs1 % RFS] + (signed<6>)imm;
         }
-        CSRLI {//(RV64)
-            encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            assembly: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] = rs1+8;
-            X[rs1_idx] = shrl(X[rs1_idx], shamt);
-        }
-        CSRLI64 {//(RV64)
-            encoding:b1000 :: 0b00 :: rs1[2:0] :: 00000 :: 0b01;
-            assembly: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] = rs1+8;
-            X[rs1_idx] = shrl(X[rs1_idx], shamt);
-        }
-        CSRAI {//(RV64)
-            encoding:b100 :: shamt[5:5] :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            assembly: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] = rs1+8;
-            X[rs1_idx] = shra(X[rs1_idx], shamt);
-        }
-        CSLLI {//(RV64)
-            encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 0b10;
-            assembly: "{name(rs1)}, {shamt}";
-            if (rs1 == 0) raise(0, 2);
-            X[rs1] = shll(X[rs1], shamt);
-        }
+
         CLDSP {//(RV64/128
             encoding: 3'b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 2'b10;
-            assembly:"{name(rd)}, {uimm}(sp)";
-            unsigned<XLEN> offs = X[2] + uimm;
-            if (rd != 0) X[rd] = sext(MEM[offs]{64});
+            assembly: "{name(rd)}, {uimm}(sp)";
+            behavior: {
+                unsigned<XLEN> offs = X[2] + uimm;
+                signed<64> res = MEM[offs];
+
+                if (rd % RFS)
+                    X[rd % RFS] = res;
+                else
+                    raise(0,2);
+            }
         }
+
         CSDSP {//(RV64/128)
             encoding: 3'b111 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 2'b10;
-            assembly:"{name(rs2)}, {uimm}(sp)";
-            unsigned<XLEN> offs = X[2] + uimm;
-            MEM[offs]{64} = X[rs2];
-        }
+            assembly: "{name(rs2)}, {uimm}(sp)";
+            behavior: {
+                unsigned<XLEN> offs = X[2] + uimm;
+                MEM[offs] = (unsigned<64>)X[rs2 % RFS];
+        	}
+		}
     }
 }
 
 InstructionSet RV128IC extends RV64IC {
-
-    instructions {
-        CSRLI {//(RV128)
-            encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            assembly: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] = rs1+8;
-            X[rs1_idx] = shrl(X[rs1_idx], shamt);
+    instructions{
+        CSRAI64 {//(RV128)
+            encoding: 3'b100 :: 0b0 :: 2'b01:: rs1[2:0] :: 0b0000 :: 2'b01;
+            assembly: "{name(8+rs1)}";
+            behavior: {
+                X[rs1 + 8] = (signed<XLEN>)X[rs1 + 8] >> 64;
+            }
         }
-        CSRAI {//(RV128)
-            encoding:b100 :: shamt[5:5] :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
-            assembly: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] = rs1+8;
-            X[rs1_idx] = shra(X[rs1_idx], shamt);
+        CSRLI64 {//(RV128)
+            encoding: 0b1000 :: 2'b00:: rs1[2:0] :: 00000 :: 2'b01;
+            assembly: "{name(8+rs1)}";
+            behavior: {
+                X[rs1 + 8] = X[rs1 + 8] << 64;
+            }
         }
-        CSLLI {//(RV128)
-            encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 0b10;
-            assembly: "{name(rs1)}, {shamt}";
-            if (rs1 == 0) raise(0, 2);
-            X[rs1] = shll(X[rs1], shamt);
+        CSLLI64 {//(RV128)
+            encoding: 3'b000:: 0b0 :: rs1[4:0] :: 0b0000 :: 2'b10;
+            assembly: "{name(rs1)}";
+            behavior: {
+                if(rs1 == 0) raise(0, 2);
+                X[rs1] = X[rs1] << 64;
+            }
         }
         CLQ { //(RV128)
-             encoding:b001 :: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
+             encoding: 3'b001:: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
+             behavior: {}
         }
         CSQ { //(RV128)
-            encoding:b101 :: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
+            encoding: 3'b101:: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
+            behavior: {}
         }
         CSQSP {//(RV128)
-            encoding:b101 :: uimm[5:4] :: uimm[9:6] :: rs2[4:0] :: 0b10;
+            encoding: 3'b101:: uimm[5:4] :: uimm[9:6] :: rs2[4:0] :: 2'b10;
+            behavior: {}
         }
     }
 }
-*/

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -1,17 +1,10 @@
 import "RISCVBase.core_desc"
 
 InstructionSet RV32IC extends RISCVBase{
-
+    architectural_state {
+        INSTR_ALIGNMENT=2;
+    }
     instructions{
-         JALR[[no_cont]]{ // overwriting the implementation if rv32i, alignment does not need to be word
-            encoding: imm[11:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1100111;
-            args_disass: "{name(rd)}, {name(rs1)}, {imm:#0x}";
-            behavior: {
-	            int<XLEN> new_pc = X[rs1] + (signed<12>)imm;
-                if(rd!=0) X[rd] = PC+4;
-                PC=new_pc & ~0x1;
-            }
-        }
         CADDI4SPN { //(RES, imm=0)
             encoding: 0b000 :: imm[5:4] :: imm[9:6] :: imm[2:2] :: imm[3:3] :: rd[2:0] :: 0b00;
             args_disass: "{name(rd)}, {imm:#05x}";

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -27,8 +27,8 @@ InstructionSet RV32IC extends RV32I {
             encoding: 0b110 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 0b00;
             args_disass: "{name(8+rs2)}, {uimm:#05x}({name(8+rs1)})";
             behavior: {
-                unsigned<XLEN> load_address = X[rs1+8] + uimm;
-                MEM[load_address] = X[rs2 + 8];
+                unsigned<XLEN> load_address = X[rs1 + 8] + uimm;
+                MEM[load_address] = (signed<32>)X[rs2 + 8];
             }
         }
 

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -10,7 +10,7 @@ InstructionSet RV32IC extends RV32I {
             encoding: 0b000 :: imm[5:4] :: imm[9:6] :: imm[2:2] :: imm[3:3] :: rd[2:0] :: 0b00;
             args_disass: "{name(rd)}, {imm:#05x}";
             behavior:
-                if (imm) X[rd+8] = X[2] + imm;
+                if (imm) X[rd + 8] = X[2] + imm;
                 else raise(0, 2);
         }
 
@@ -18,8 +18,8 @@ InstructionSet RV32IC extends RV32I {
             encoding: 0b010 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 0b00;
             args_disass: "{name(8+rd)}, {uimm:#05x}({name(8+rs1)})";
             behavior: {
-                unsigned<XLEN> load_address = X[rs1+8] + uimm;
-                X[rd+8] = (signed<32>)MEM[load_address];
+                unsigned<XLEN> load_address = X[rs1 + 8] + uimm;
+                X[rd + 8] = (signed<32>)MEM[load_address];
             }
         }
 
@@ -162,7 +162,7 @@ InstructionSet RV32IC extends RV32I {
         CBEQZ [[no_cont]] [[cond]] {//(RV32)
             encoding: 0b110 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 0b01;
             args_disass: "{name(8+rs1)}, {imm:#05x}";
-            behavior: if (X[rs1+8] == 0) PC = PC + (signed<9>)imm;
+            behavior: if (X[rs1 + 8] == 0) PC = PC + (signed<9>)imm;
         }
 
         CBNEZ [[no_cont]] [[cond]] {//(RV32)

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -249,171 +249,181 @@ InstructionSet RV32IC extends RV32I {
     }
 }
 
-/*
 InstructionSet RV32FC extends RV32F {
-    constants {
-        FLEN
-    }
-    registers {
-        [31:0] F[FLEN]
-    }
     instructions {
         CFLW {
             encoding: 0b011 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 0b00;
             args_disass:"f(8+{rd}), {uimm}({name(8+rs1)})";
-            val offs[XLEN] < = X[rs1+8]+uimm;
-            val res[32] < = MEM[offs]{32};
-            if (FLEN == 32)
-                F[rd+8] < = res;
-            else { // NaN boxing
-                val upper[FLEN] < = -1;
-                F[rd+8] < = (upper<<32) :: zext(res, FLEN);
+            behavior: {
+                unsigned<XLEN> offs = X[rs1+8]+uimm;
+                unsigned<32> res = (unsigned<32>)MEM[offs];
+                if (FLEN == 32)
+                    F[rd + 8] = res;
+                else { // NaN boxing
+                    unsigned<FLEN> upper = -1;
+                    F[rd + 8] = (upper << 32) | res;
+                }
             }
         }
+
         CFSW {
             encoding: 0b111 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 0b00;
             args_disass:"f(8+{rs2}), {uimm}({name(8+rs1)})";
-            val offs[XLEN] < = X[rs1+8]+uimm;
-            MEM[offs]{32} <= F[rs2+8]{32};
-        }
-        CFLWSP {
-            encoding:b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 0b10;
-            args_disass:"f {rd}, {uimm}(x2)";
-            val offs[XLEN] < = X[2]+uimm;
-            val res[32] < = MEM[offs]{32};
-            if (FLEN == 32)
-                F[rd] < = res;
-            else { // NaN boxing
-                val upper[FLEN] < = -1;
-                F[rd] < = (upper<<32) :: zext(res, FLEN);
+            behavior: {
+                unsigned<XLEN> offs = X[rs1 + 8] + uimm;
+                MEM[offs] = (unsigned<32>)F[rs2 + 8];
             }
         }
+
+        CFLWSP {
+            encoding: 0b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 0b10;
+            args_disass:"f {rd}, {uimm}(x2)";
+            behavior: {
+                unsigned<XLEN> offs = X[2]+uimm;
+                unsigned<32> res = (unsigned<32>)MEM[offs];
+                if (FLEN == 32)
+                    F[rd] = res;
+                else { // NaN boxing
+                    unsigned<FLEN> upper = -1;
+                    F[rd] = (upper << 32) | res;
+                }
+            }
+        }
+
         CFSWSP {
-            encoding:b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 0b10;
+            encoding: 0b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 0b10;
             args_disass:"f {rs2}, {uimm}(x2), ";
-            val offs[XLEN] < = X[2]+uimm;
-            MEM[offs]{32} <= F[rs2]{32};
+            behavior: {
+                unsigned<XLEN> offs = X[2] + uimm;
+                MEM[offs] = (unsigned<32>)F[rs2];
+            }
         }
     }
 }
 
 InstructionSet RV32DC extends RV32D {
-    constants {
-        FLEN
-    }
-    registers {
-        [31:0] F[FLEN]
-    }
     instructions {
         CFLD { //(RV32/64)
             encoding: 0b001 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
             args_disass:"f(8+{rd}), {uimm}({name(8+rs1)})";
-            val offs[XLEN] < = X[rs1+8]+uimm;
-            val res[64] < = MEM[offs]{64};
-            if (FLEN == 64)
-                F[rd+8] < = res;
-            else { // NaN boxing
-                val upper[FLEN] < = -1;
-                F[rd+8] < = (upper<<64) :: res;
+            behavior: {
+                unsigned<XLEN> offs = X[rs1 + 8] + uimm;
+                unsigned<64> res = (unsigned<64>)MEM[offs];
+                if (FLEN == 64)
+                    F[rd+8] = res;
+                else { // NaN boxing
+                    unsigned<FLEN> upper = -1;
+                    F[rd+8] = (upper << 64) | res;
+                }
             }
-         }
+        }
+
         CFSD { //(RV32/64)
             encoding: 0b101 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
             args_disass:"f(8+{rs2}), {uimm}({name(8+rs1)})";
-            val offs[XLEN] < = X[rs1+8]+uimm;
-            MEM[offs]{64} <= F[rs2+8]{64};
-        }
-        CFLDSP {//(RV32/64)
-            encoding:b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
-            args_disass:"f {rd}, {uimm}(x2)";
-            val offs[XLEN] < = X[2]+uimm;
-            val res[64] < = MEM[offs]{64};
-            if (FLEN == 64)
-                F[rd] < = res;
-            else { // NaN boxing
-                val upper[FLEN] < = -1;
-                F[rd] < = (upper<<64) :: zext(res, FLEN);
+            behavior: {
+                unsigned<XLEN> offs = X[rs1 + 8] + uimm;
+                MEM[offs] = (unsigned<64>)F[rs2 + 8];
             }
         }
+
+        CFLDSP {//(RV32/64)
+            encoding: 0b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
+            args_disass:"f {rd}, {uimm}(x2)";
+            behavior: {
+                unsigned<XLEN> offs = X[2] + uimm;
+                unsigned<64> res = (unsigned<64>)MEM[offs];
+                if (FLEN == 64)
+                    F[rd] = res;
+                else { // NaN boxing
+                    unsigned<FLEN> upper = -1;
+                    F[rd] = (upper << 64) | res;
+                }
+            }
+        }
+
         CFSDSP {//(RV32/64)
-            encoding:b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 0b10;
+            encoding: 0b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 0b10;
             args_disass:"f {rs2}, {uimm}(x2), ";
-            val offs[XLEN] < = X[2]+uimm;
-            MEM[offs]{64} <= F[rs2]{64};
+            behavior: {
+                unsigned<XLEN> offs = X[2] + uimm;
+                MEM[offs] = (unsigned<64>)F[rs2];
+            }
         }
     }
 }
 
+/*
 InstructionSet RV64IC extends RV32IC {
 
     instructions {
         CLD {//(RV64/128)
             encoding:b011 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
             args_disass: "{name(8+rd)}, {uimm},({name(8+rs1)})";
-            val offs[XLEN] < = X[rs1+8] + uimm;
-            X[rd+8] <= sext(MEM[offs]{64});
+            unsigned<XLEN> offs = X[rs1+8] + uimm;
+            X[rd+8] = (signed<64>)MEM[offs];
         }
         CSD { //(RV64/128)
             encoding:b111 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
             args_disass: "{name(8+rs2)}, {uimm},({name(8+rs1)})";
-            val offs[XLEN] < = X[rs1+8] + uimm;
-            MEM[offs]{64} < = X[rs2+8];
+            unsigned<XLEN> offs = X[rs1+8] + uimm;
+            MEM[offs] = (signed<64>)X[rs2+8];
         }
         CSUBW {//(RV64/128, RV32 res)
             encoding:b100 :: 0b1 :: 0b11 :: rd[2:0] :: 0b00 :: rs2[2:0] :: 0b01;
             args_disass: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
-            val res[32] < = X[rd+8]{32} - X[rs2+8]{32};
-            X[rd+8] < = sext(res);
+            unsigned<32> res = (unsigned<32>)X[rd+8] - (unsigned<32>)X[rs2+8];
+            X[rd+8] = (signed)res;
         }
         CADDW {//(RV64/128 RV32 res)
             encoding:b100 :: 0b1 :: 0b11 :: rd[2:0] :: 0b01 :: rs2[2:0] :: 0b01;
             args_disass: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
-            val res[32] < = X[rd+8]{32} + X[rs2+8]{32};
-            X[rd+8] < = sext(res);
+            unsigned<32> res = (unsigned<32>)X[rd+8] + (unsigned<32>)X[rs2+8];
+            X[rd+8] = (signed)res;
         }
         CADDIW {//(RV64/128)
-            encoding:b001 :: imm[5:5]s :: rs1[4:0] :: imm[4:0]s :: 0b01;
+            encoding:b001 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 0b01;
             args_disass: "{name(rs1)}, {imm:#05x}";
             if (rs1 != 0) {
-                val res[32] < = X[rs1]{32}'s + imm;
-                X[rs1] < = sext(res);
+                unsigned<32> res = (signed)X[rs1] + (signed)imm;
+                X[rs1] = (signed)res;
             }
         }
         CSRLI {//(RV64)
             encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] < = rs1+8;
-            X[rs1_idx] < = shrl(X[rs1_idx], shamt);
+            val rs1_idx[5] = rs1+8;
+            X[rs1_idx] = shrl(X[rs1_idx], shamt);
         }
         CSRLI64 {//(RV64)
             encoding:b1000 :: 0b00 :: rs1[2:0] :: 00000 :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] < = rs1+8;
-            X[rs1_idx] < = shrl(X[rs1_idx], shamt);
+            val rs1_idx[5] = rs1+8;
+            X[rs1_idx] = shrl(X[rs1_idx], shamt);
         }
         CSRAI {//(RV64)
             encoding:b100 :: shamt[5:5] :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] < = rs1+8;
-            X[rs1_idx] < = shra(X[rs1_idx], shamt);
+            val rs1_idx[5] = rs1+8;
+            X[rs1_idx] = shra(X[rs1_idx], shamt);
         }
         CSLLI {//(RV64)
             encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 0b10;
             args_disass: "{name(rs1)}, {shamt}";
             if (rs1 == 0) raise(0, 2);
-            X[rs1] < = shll(X[rs1], shamt);
+            X[rs1] = shll(X[rs1], shamt);
         }
         CLDSP {//(RV64/128
             encoding:b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
             args_disass:"{name(rd)}, {uimm}(sp)";
-            val offs[XLEN] < = X[2] + uimm;
-            if (rd != 0) X[rd] <= sext(MEM[offs]{64});
+            unsigned<XLEN> offs = X[2] + uimm;
+            if (rd != 0) X[rd] = sext(MEM[offs]{64});
         }
         CSDSP {//(RV64/128)
             encoding:b111 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 0b10;
             args_disass:"{name(rs2)}, {uimm}(sp)";
-            val offs[XLEN] < = X[2] + uimm;
-            MEM[offs]{64} < = X[rs2];
+            unsigned<XLEN> offs = X[2] + uimm;
+            MEM[offs]{64} = X[rs2];
         }
     }
 }
@@ -424,20 +434,20 @@ InstructionSet RV128IC extends RV64IC {
         CSRLI {//(RV128)
             encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] < = rs1+8;
-            X[rs1_idx] < = shrl(X[rs1_idx], shamt);
+            val rs1_idx[5] = rs1+8;
+            X[rs1_idx] = shrl(X[rs1_idx], shamt);
         }
         CSRAI {//(RV128)
             encoding:b100 :: shamt[5:5] :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] < = rs1+8;
-            X[rs1_idx] < = shra(X[rs1_idx], shamt);
+            val rs1_idx[5] = rs1+8;
+            X[rs1_idx] = shra(X[rs1_idx], shamt);
         }
         CSLLI {//(RV128)
             encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 0b10;
             args_disass: "{name(rs1)}, {shamt}";
             if (rs1 == 0) raise(0, 2);
-            X[rs1] < = shll(X[rs1], shamt);
+            X[rs1] = shll(X[rs1], shamt);
         }
         CLQ { //(RV128)
              encoding:b001 :: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -260,8 +260,7 @@ InstructionSet RV32FC extends RV32F {
                 if (FLEN == 32)
                     F[rd + 8] = res;
                 else { // NaN boxing
-                    unsigned<FLEN> upper = -1;
-                    F[rd + 8] = (upper << 32) | res;
+                    F[rd + 8] = (-1 << 32) | res;
                 }
             }
         }
@@ -284,8 +283,7 @@ InstructionSet RV32FC extends RV32F {
                 if (FLEN == 32)
                     F[rd] = res;
                 else { // NaN boxing
-                    unsigned<FLEN> upper = -1;
-                    F[rd] = (upper << 32) | res;
+                    F[rd] = (-1 << 32) | res;
                 }
             }
         }
@@ -312,8 +310,7 @@ InstructionSet RV32DC extends RV32D {
                 if (FLEN == 64)
                     F[rd+8] = res;
                 else { // NaN boxing
-                    unsigned<FLEN> upper = -1;
-                    F[rd+8] = (upper << 64) | res;
+                    F[rd+8] = (-1 << 64) | res;
                 }
             }
         }
@@ -336,8 +333,7 @@ InstructionSet RV32DC extends RV32D {
                 if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    unsigned<FLEN> upper = -1;
-                    F[rd] = (upper << 64) | res;
+                    F[rd] = (-1 << 64) | res;
                 }
             }
         }

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -1,415 +1,448 @@
-import "RISCVBase.core_desc"
+import "RV32I.core_desc"
 
-InstructionSet RV32IC extends RISCVBase{
+InstructionSet RV32IC extends RV32I {
     architectural_state {
-        INSTR_ALIGNMENT=2;
+        INSTR_ALIGNMENT = 2;
     }
+
     instructions{
         CADDI4SPN { //(RES, imm=0)
             encoding: 0b000 :: imm[5:4] :: imm[9:6] :: imm[2:2] :: imm[3:3] :: rd[2:0] :: 0b00;
             args_disass: "{name(rd)}, {imm:#05x}";
             behavior:
-            	if(imm) X[rd+8] = X[2] + imm;
-            	else raise(0, 2);
+                if (imm) X[rd+8] = X[2] + imm;
+                else raise(0, 2);
         }
+
         CLW { // (RV32)
             encoding: 0b010 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 0b00;
             args_disass: "{name(8+rd)}, {uimm:#05x}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1+8] + uimm;
-	            X[rd+8] = (signed<32>)MEM[load_address];
+                X[rd+8] = (signed<32>)MEM[load_address];
             }
         }
+
         CSW {//(RV32)
             encoding: 0b110 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 0b00;
             args_disass: "{name(8+rs2)}, {uimm:#05x}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> load_address = X[rs1+8] + uimm;
-                MEM[load_address] = X[rs2+8];
+                MEM[load_address] = X[rs2 + 8];
             }
         }
+
         CADDI {//(RV32)
             encoding: 0b000 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 0b01;
             args_disass: "{name(rs1)}, {imm:#05x}";
             behavior: X[rs1] = X[rs1] + (signed<6>)imm;
         }
+
         CNOP {
             encoding: 0b000 :: nzimm[5:5] :: 0b00000 :: nzimm[4:0] :: 0b01;
             behavior: {
-                //if(!nzimm) raise(0, 2);
+                //if (!nzimm) raise(0, 2);
             }
         }
+
         // CJAL will be overwritten by CADDIW for RV64/128
-        CJAL[[no_cont]] {//(RV32)
+        CJAL [[no_cont]] {//(RV32)
             encoding: 0b001 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 0b01;
             args_disass: "{imm:#05x}";
             behavior: {
-	            X[1] = PC+2;
-	            PC=PC+(signed<12>)imm;
+                X[1] = PC + 2;
+                PC = PC + (signed<12>)imm;
             }
         }
+
         CLI {//(RV32)
             encoding: 0b010 :: imm[5:5] :: rd[4:0] :: imm[4:0] :: 0b01;
             args_disass: "{name(rd)}, {imm:#05x}";
             behavior: {
-	            if(rd != 0)   //rd==0 is a hint, so no trap
-	               X[rd] = (unsigned<XLEN>)(signed)imm;
+                if (rd != 0) X[rd] = (signed)imm;
             }
         }
-        // order matters here as CADDI16SP overwrites CLUI for rd==2
+
+        // order matters here as CADDI16SP overwrites CLUI for rd == 2
         CLUI {//(RV32)
             encoding: 0b011 :: imm[17:17] :: rd[4:0] :: imm[16:12] :: 0b01;
             args_disass: "{name(rd)}, {imm:#05x}";
             behavior: {
-                if(imm == 0) raise(0, 2);
-                if(rd != 0) 
-                    X[rd] = (signed<18>)imm;
+                if (imm == 0) raise(0, 2);
+                if (rd != 0) X[rd] = (signed<18>)imm;
             }
         }
+
         CADDI16SP {//(RV32)
             encoding: 0b011 :: nzimm[9:9] :: 0b00010 :: nzimm[4:4] :: nzimm[6:6] :: nzimm[8:7] :: nzimm[5:5] :: 0b01;
             args_disass: "{nzimm:#05x}";
-            behavior:  
-                if(nzimm) X[2] = X[2] + (signed<10>)nzimm;
+            behavior:
+                if (nzimm) X[2] = X[2] + (signed<10>)nzimm;
                 else raise(0, 2);
         }
+
         __reserved_clui {//(RV32)
             encoding: 0b011 :: 0b0 :: rd[4:0] :: 0b00000 :: 0b01;
             behavior: raise(0, 2);
         }
+
         CSRLI {//(RV32 nse)
             encoding: 0b100 :: 0b0 :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
             behavior: {
-	            unsigned rs1_idx = rs1+8;
-	            X[rs1_idx] = X[rs1_idx] >> shamt;
+                unsigned<32> rs1_idx = rs1 + 8;
+                X[rs1_idx] = X[rs1_idx] >> shamt;
             }
         }
+
         CSRAI {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
-            behavior: if(shamt){
-	            unsigned rs1_idx = rs1+8;
-	            X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> shamt;
-            } else if(XLEN==128){
-                unsigned rs1_idx = rs1+8;
-                X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> 64;               
-            } 
+            behavior: {
+                unsigned<32> rs1_idx = rs1+8;
+                if (shamt) {
+                    X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> shamt;
+                } else if (XLEN == 128) {
+                    X[rs1_idx] = ((signed<XLEN>)X[rs1_idx]) >> 64;
+                }
+            }
         }
+
         CANDI {//(RV32)
             encoding: 0b100 :: imm[5:5] :: 0b10 :: rs1[2:0] :: imm[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {imm:#05x}";
             behavior: {
-	            unsigned rs1_idx = rs1 + 8;
-	            X[rs1_idx] = X[rs1_idx] & (signed<6>)imm;
+                unsigned<32> rs1_idx = rs1 + 8;
+                X[rs1_idx] = X[rs1_idx] & (signed<6>)imm;
             }
         }
+
         CSUB {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b00 :: rs2[2:0] :: 0b01;
             args_disass: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-            	unsigned rd_idx = rd + 8;
-            	X[rd_idx] = X[rd_idx] - X[rs2 + 8];
+                unsigned<32> rd_idx = rd + 8;
+                X[rd_idx] = X[rd_idx] - X[rs2 + 8];
             }
         }
+
         CXOR {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b01 :: rs2[2:0] :: 0b01;
             args_disass: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-            	unsigned rd_idx = rd + 8;
-            	X[rd_idx] = X[rd_idx] ^ X[rs2 + 8];
+                unsigned<32> rd_idx = rd + 8;
+                X[rd_idx] = X[rd_idx] ^ X[rs2 + 8];
             }
         }
+
         COR {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b10 :: rs2[2:0] :: 0b01;
             args_disass: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-	            unsigned rd_idx = rd + 8;
-            	X[rd_idx] = X[rd_idx] | X[rs2 + 8];
+                unsigned<32> rd_idx = rd + 8;
+                X[rd_idx] = X[rd_idx] | X[rs2 + 8];
             }
         }
+
         CAND {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b11 :: rd[2:0] :: 0b11 :: rs2[2:0] :: 0b01;
             args_disass: "{name(8+rd)}, {name(8+rs2)}";
             behavior: {
-            	unsigned rd_idx = rd + 8;
-            	X[rd_idx] = X[rd_idx] & X[rs2 + 8];
+                unsigned<32> rd_idx = rd + 8;
+                X[rd_idx] = X[rd_idx] & X[rs2 + 8];
             }
         }
-        CJ[[no_cont]] {//(RV32)
+
+        CJ [[no_cont]] {//(RV32)
             encoding: 0b101 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 0b01;
             args_disass: "{imm:#05x}";
-            behavior: PC=PC + (signed<12>)imm;
+            behavior: PC = PC + (signed<12>)imm;
         }
-        CBEQZ[[no_cont]] [[cond]] {//(RV32)
+
+        CBEQZ [[no_cont]] [[cond]] {//(RV32)
             encoding: 0b110 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 0b01;
             args_disass: "{name(8+rs1)}, {imm:#05x}";
-            behavior: if(X[rs1+8]==0) PC = PC + (signed<9>)imm;
+            behavior: if (X[rs1+8] == 0) PC = PC + (signed<9>)imm;
         }
-        CBNEZ[[no_cont]] [[cond]] {//(RV32)
+
+        CBNEZ [[no_cont]] [[cond]] {//(RV32)
             encoding: 0b111 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 0b01;
             args_disass: "{name(8+rs1)}, {imm:#05x}";
-            behavior: if(X[rs1+8]!=0) PC = PC + (signed<9>)imm;
+            behavior: if (X[rs1+8] != 0) PC = PC + (signed<9>)imm;
         }
+
         CSLLI {//(RV32)
             encoding: 0b000 :: 0b0 :: rs1[4:0] :: nzuimm[4:0] :: 0b10;
             args_disass: "{name(rs1)}, {nzuimm}";
-            behavior: if(nzuimm) X[rs1] = X[rs1]<< nzuimm;
+            behavior: if (nzuimm) X[rs1] = X[rs1]<< nzuimm;
         }
+
         CLWSP {//
             encoding: 0b010 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 0b10;
             args_disass: "{name(rd)}, sp, {uimm:#05x}";
-            behavior: if(rd){
-    	        unsigned<XLEN> offs = X[2] + uimm;
-                X[rd] = (signed<32>)MEM[offs];
-            } else 
-                raise(0,2);
+            behavior: {
+                if (rd) {
+                    unsigned<XLEN> offs = X[2] + uimm;
+                    X[rd] = (signed<32>)MEM[offs];
+                } else {
+                    raise(0,2);
+                }
+            }
         }
+
         // order matters as CJR is a special case of CMV
         CMV {//(RV32)
             encoding: 0b100 :: 0b0 :: rd[4:0] :: rs2[4:0] :: 0b10;
             args_disass: "{name(rd)}, {name(rs2)}";
-            behavior: if(rd!=0) X[rd] = X[rs2];
+            behavior: if (rd != 0) X[rd] = X[rs2];
         }
-        CJR[[no_cont]] {//(RV32)
+
+        CJR [[no_cont]] {//(RV32)
             encoding: 0b100 :: 0b0 :: rs1[4:0] :: 0b00000 :: 0b10;
             args_disass: "{name(rs1)}";
-            behavior: if(rs1)
+            behavior: if (rs1)
                 PC = X[rs1] & ~0x1;
             else
                 raise(0,2);
         }
+
         __reserved_cmv {//(RV32)
             encoding: 0b100 :: 0b0 :: 0b00000 :: 0b00000 :: 0b10;
             behavior: raise(0,2);
         }
+
         // order matters as CEBREAK is a special case of CJALR which is a special case of CADD
         CADD {//(RV32)
             encoding: 0b100 :: 0b1 :: rd[4:0] :: rs2[4:0] :: 0b10;
             args_disass: "{name(rd)}, {name(rs2)}";
-            behavior: if(rd!=0) X[rd] = X[rd] + X[rs2];
+            behavior: if (rd != 0) X[rd] = X[rd] + X[rs2];
         }
-        CJALR[[no_cont]] {//(RV32)
+
+        CJALR [[no_cont]] {//(RV32)
             encoding: 0b100 :: 0b1 :: rs1[4:0] :: 0b00000 :: 0b10;
             args_disass: "{name(rs1)}";
             behavior: {
                 signed<XLEN> new_pc = X[rs1];
-                X[1] = PC+2;
-                PC=new_pc & ~0x1;
+                X[1] = PC + 2;
+                PC = new_pc & ~0x1;
             }
         }
-        CEBREAK[[no_cont]] {//(RV32)
+
+        CEBREAK [[no_cont]] {//(RV32)
             encoding: 0b100 :: 0b1 :: 0b00000 :: 0b00000 :: 0b10;
-            behavior:            raise(0, 3);
+            behavior: raise(0, 3);
         }
+
         CSWSP {//
             encoding: 0b110 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 0b10;
             args_disass: "{name(rs2)}, {uimm:#05x}(sp)";
             behavior: {
-	            unsigned<XLEN> offs = X[2] + uimm;
-	            MEM[offs] = (unsigned<32>)X[rs2];
+                unsigned<XLEN> offs = X[2] + uimm;
+                MEM[offs] = (unsigned<32>)X[rs2];
             }
         }
-        DII[[no_cont]] { // Defined Illegal Instruction
+
+        DII [[no_cont]] { // Defined Illegal Instruction
             encoding: 0b000 :: 0b0 :: 0b00000 :: 0b00000 :: 0b00;
-            behavior:            raise(0, 2);
+            behavior: raise(0, 2);
         }
     }
 }
+
 /*
-InstructionSet RV32FC extends RISCVBase{
+InstructionSet RV32FC extends RV32F {
     constants {
         FLEN
     }
-    registers { 
-        [31:0]   F[FLEN]
+    registers {
+        [31:0] F[FLEN]
     }
-    instructions{
+    instructions {
         CFLW {
             encoding: 0b011 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 0b00;
             args_disass:"f(8+{rd}), {uimm}({name(8+rs1)})";
-            val offs[XLEN] <= X[rs1+8]+uimm;
-            val res[32] <= MEM[offs]{32};
-            if(FLEN==32)
-                F[rd+8] <= res;
+            val offs[XLEN] < = X[rs1+8]+uimm;
+            val res[32] < = MEM[offs]{32};
+            if (FLEN == 32)
+                F[rd+8] < = res;
             else { // NaN boxing
-                val upper[FLEN] <= -1;
-                F[rd+8] <= (upper<<32) :: zext(res, FLEN);
+                val upper[FLEN] < = -1;
+                F[rd+8] < = (upper<<32) :: zext(res, FLEN);
             }
-        } 
+        }
         CFSW {
             encoding: 0b111 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 0b00;
             args_disass:"f(8+{rs2}), {uimm}({name(8+rs1)})";
-            val offs[XLEN] <= X[rs1+8]+uimm;
-            MEM[offs]{32}<=F[rs2+8]{32};
+            val offs[XLEN] < = X[rs1+8]+uimm;
+            MEM[offs]{32} <= F[rs2+8]{32};
         }
         CFLWSP {
             encoding:b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 0b10;
-            args_disass:"f{rd}, {uimm}(x2)";
-            val offs[XLEN] <= X[2]+uimm;
-            val res[32] <= MEM[offs]{32};
-            if(FLEN==32)
-                F[rd] <= res;
+            args_disass:"f {rd}, {uimm}(x2)";
+            val offs[XLEN] < = X[2]+uimm;
+            val res[32] < = MEM[offs]{32};
+            if (FLEN == 32)
+                F[rd] < = res;
             else { // NaN boxing
-                val upper[FLEN] <= -1;
-                F[rd] <= (upper<<32) :: zext(res, FLEN);
+                val upper[FLEN] < = -1;
+                F[rd] < = (upper<<32) :: zext(res, FLEN);
             }
         }
         CFSWSP {
             encoding:b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 0b10;
-            args_disass:"f{rs2}, {uimm}(x2), ";
-            val offs[XLEN] <= X[2]+uimm;
-            MEM[offs]{32}<=F[rs2]{32};
-        }        
+            args_disass:"f {rs2}, {uimm}(x2), ";
+            val offs[XLEN] < = X[2]+uimm;
+            MEM[offs]{32} <= F[rs2]{32};
+        }
     }
 }
 
-InstructionSet RV32DC extends RISCVBase{
+InstructionSet RV32DC extends RV32D {
     constants {
         FLEN
     }
-    registers { 
-        [31:0]   F[FLEN]
+    registers {
+        [31:0] F[FLEN]
     }
-    instructions{
+    instructions {
         CFLD { //(RV32/64)
             encoding: 0b001 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
             args_disass:"f(8+{rd}), {uimm}({name(8+rs1)})";
-            val offs[XLEN] <= X[rs1+8]+uimm;
-            val res[64] <= MEM[offs]{64};
-            if(FLEN==64)
-                F[rd+8] <= res;
+            val offs[XLEN] < = X[rs1+8]+uimm;
+            val res[64] < = MEM[offs]{64};
+            if (FLEN == 64)
+                F[rd+8] < = res;
             else { // NaN boxing
-                val upper[FLEN] <= -1;
-                F[rd+8] <= (upper<<64) :: res;
+                val upper[FLEN] < = -1;
+                F[rd+8] < = (upper<<64) :: res;
             }
          }
         CFSD { //(RV32/64)
             encoding: 0b101 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
             args_disass:"f(8+{rs2}), {uimm}({name(8+rs1)})";
-            val offs[XLEN] <= X[rs1+8]+uimm;
-            MEM[offs]{64}<=F[rs2+8]{64};
-        } 
+            val offs[XLEN] < = X[rs1+8]+uimm;
+            MEM[offs]{64} <= F[rs2+8]{64};
+        }
         CFLDSP {//(RV32/64)
             encoding:b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
-            args_disass:"f{rd}, {uimm}(x2)";
-            val offs[XLEN] <= X[2]+uimm;
-            val res[64] <= MEM[offs]{64};
-            if(FLEN==64)
-                F[rd] <= res;
+            args_disass:"f {rd}, {uimm}(x2)";
+            val offs[XLEN] < = X[2]+uimm;
+            val res[64] < = MEM[offs]{64};
+            if (FLEN == 64)
+                F[rd] < = res;
             else { // NaN boxing
-                val upper[FLEN] <= -1;
-                F[rd] <= (upper<<64) :: zext(res, FLEN);
+                val upper[FLEN] < = -1;
+                F[rd] < = (upper<<64) :: zext(res, FLEN);
             }
         }
         CFSDSP {//(RV32/64)
             encoding:b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 0b10;
-            args_disass:"f{rs2}, {uimm}(x2), ";
-            val offs[XLEN] <= X[2]+uimm;
-            MEM[offs]{64}<=F[rs2]{64};
+            args_disass:"f {rs2}, {uimm}(x2), ";
+            val offs[XLEN] < = X[2]+uimm;
+            MEM[offs]{64} <= F[rs2]{64};
         }
     }
 }
 
 InstructionSet RV64IC extends RV32IC {
 
-    instructions{
-        CLD {//(RV64/128) 
+    instructions {
+        CLD {//(RV64/128)
             encoding:b011 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
             args_disass: "{name(8+rd)}, {uimm},({name(8+rs1)})";
-            val offs[XLEN] <= X[rs1+8] + uimm;
-            X[rd+8]<=sext(MEM[offs]{64});
+            val offs[XLEN] < = X[rs1+8] + uimm;
+            X[rd+8] <= sext(MEM[offs]{64});
         }
-        CSD { //(RV64/128) 
+        CSD { //(RV64/128)
             encoding:b111 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
             args_disass: "{name(8+rs2)}, {uimm},({name(8+rs1)})";
-            val offs[XLEN] <= X[rs1+8] + uimm;
-            MEM[offs]{64} <= X[rs2+8];
+            val offs[XLEN] < = X[rs1+8] + uimm;
+            MEM[offs]{64} < = X[rs2+8];
         }
         CSUBW {//(RV64/128, RV32 res)
             encoding:b100 :: 0b1 :: 0b11 :: rd[2:0] :: 0b00 :: rs2[2:0] :: 0b01;
             args_disass: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
-            val res[32] <= X[rd+8]{32} - X[rs2+8]{32};
-            X[rd+8] <= sext(res);
+            val res[32] < = X[rd+8]{32} - X[rs2+8]{32};
+            X[rd+8] < = sext(res);
         }
         CADDW {//(RV64/128 RV32 res)
             encoding:b100 :: 0b1 :: 0b11 :: rd[2:0] :: 0b01 :: rs2[2:0] :: 0b01;
-            args_disass: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";   
-            val res[32] <= X[rd+8]{32} + X[rs2+8]{32};
-            X[rd+8] <= sext(res);
+            args_disass: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
+            val res[32] < = X[rd+8]{32} + X[rs2+8]{32};
+            X[rd+8] < = sext(res);
         }
         CADDIW {//(RV64/128)
             encoding:b001 :: imm[5:5]s :: rs1[4:0] :: imm[4:0]s :: 0b01;
             args_disass: "{name(rs1)}, {imm:#05x}";
-            if(rs1 != 0){
-                val res[32] <= X[rs1]{32}'s + imm;
-                X[rs1] <= sext(res);
-            } 
+            if (rs1 != 0) {
+                val res[32] < = X[rs1]{32}'s + imm;
+                X[rs1] < = sext(res);
+            }
         }
         CSRLI {//(RV64)
             encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] <= rs1+8;
-            X[rs1_idx] <= shrl(X[rs1_idx], shamt);
+            val rs1_idx[5] < = rs1+8;
+            X[rs1_idx] < = shrl(X[rs1_idx], shamt);
         }
         CSRLI64 {//(RV64)
             encoding:b1000 :: 0b00 :: rs1[2:0] :: 00000 :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] <= rs1+8;
-            X[rs1_idx] <= shrl(X[rs1_idx], shamt);
+            val rs1_idx[5] < = rs1+8;
+            X[rs1_idx] < = shrl(X[rs1_idx], shamt);
         }
         CSRAI {//(RV64)
             encoding:b100 :: shamt[5:5] :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] <= rs1+8;
-            X[rs1_idx] <= shra(X[rs1_idx], shamt);
+            val rs1_idx[5] < = rs1+8;
+            X[rs1_idx] < = shra(X[rs1_idx], shamt);
         }
         CSLLI {//(RV64)
             encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 0b10;
             args_disass: "{name(rs1)}, {shamt}";
-            if(rs1 == 0) raise(0, 2);
-            X[rs1] <= shll(X[rs1], shamt);
+            if (rs1 == 0) raise(0, 2);
+            X[rs1] < = shll(X[rs1], shamt);
         }
         CLDSP {//(RV64/128
             encoding:b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 0b10;
             args_disass:"{name(rd)}, {uimm}(sp)";
-            val offs[XLEN] <= X[2] + uimm;
-            if(rd!=0) X[rd]<=sext(MEM[offs]{64});
+            val offs[XLEN] < = X[2] + uimm;
+            if (rd != 0) X[rd] <= sext(MEM[offs]{64});
         }
         CSDSP {//(RV64/128)
             encoding:b111 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 0b10;
             args_disass:"{name(rs2)}, {uimm}(sp)";
-            val offs[XLEN] <= X[2] + uimm;
-            MEM[offs]{64} <= X[rs2];
+            val offs[XLEN] < = X[2] + uimm;
+            MEM[offs]{64} < = X[rs2];
         }
     }
 }
 
 InstructionSet RV128IC extends RV64IC {
 
-    instructions{
+    instructions {
         CSRLI {//(RV128)
             encoding:b100 :: shamt[5:5] :: 0b00 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] <= rs1+8;
-            X[rs1_idx] <= shrl(X[rs1_idx], shamt);
+            val rs1_idx[5] < = rs1+8;
+            X[rs1_idx] < = shrl(X[rs1_idx], shamt);
         }
         CSRAI {//(RV128)
             encoding:b100 :: shamt[5:5] :: 0b01 :: rs1[2:0] :: shamt[4:0] :: 0b01;
             args_disass: "{name(8+rs1)}, {shamt}";
-            val rs1_idx[5] <= rs1+8;
-            X[rs1_idx] <= shra(X[rs1_idx], shamt);
+            val rs1_idx[5] < = rs1+8;
+            X[rs1_idx] < = shra(X[rs1_idx], shamt);
         }
         CSLLI {//(RV128)
             encoding:b000 :: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 0b10;
             args_disass: "{name(rs1)}, {shamt}";
-            if(rs1 == 0) raise(0, 2);
-            X[rs1] <= shll(X[rs1], shamt);
+            if (rs1 == 0) raise(0, 2);
+            X[rs1] < = shll(X[rs1], shamt);
         }
         CLQ { //(RV128)
              encoding:b001 :: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 0b00;
         }
-        CSQ { //(RV128) 
+        CSQ { //(RV128)
             encoding:b101 :: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 0b00;
         }
         CSQSP {//(RV128)

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -222,7 +222,7 @@ InstructionSet RV32IC extends RV32I {
             encoding: 0b100 :: 0b1 :: rs1[4:0] :: 0b00000 :: 0b10;
             args_disass: "{name(rs1)}";
             behavior: {
-                signed<XLEN> new_pc = X[rs1];
+                unsigned<XLEN> new_pc = X[rs1];
                 X[1] = PC + 2;
                 PC = new_pc & ~0x1;
             }

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -7,19 +7,19 @@ InstructionSet RV32D extends RV32F {
     }
 
     functions {
-        extern unsigned<32> fadd_d(unsigned<32>, unsigned<32>, unsigned char);
-        extern unsigned<32> fsub_d(unsigned<32>, unsigned<32>, unsigned char);
-        extern unsigned<32> fmul_d(unsigned<32>, unsigned<32>, unsigned char);
-        extern unsigned<32> fdiv_d(unsigned<32>, unsigned<32>, unsigned char);
-        extern unsigned<32> fmadd_d(unsigned<32>, unsigned<32>, unsigned<32>, unsigned<32>, unsigned char);
-        extern unsigned<32> fsel_d(unsigned<32>, unsigned<32>, unsigned<32>);
-        extern unsigned<32> fsqrt_d(unsigned<32>, unsigned char);
-        extern unsigned<32> fcmp_d(unsigned<32>, unsigned<32>, unsigned<32>);
-        extern unsigned<32> fcvt_d(unsigned<32>, unsigned<32>, unsigned char);
-        extern unsigned<32> fconv_d2f(unsigned<64>);
-        extern unsigned<64> fconv_f2d(unsigned<32>);
-        extern unsigned<32> unbox_d(unsigned<64>);
-        extern unsigned<32> fclass_d(unsigned<32>);
+        extern unsigned<64> fadd_d(unsigned<64>, unsigned<64>, unsigned char);
+        extern unsigned<64> fsub_d(unsigned<64>, unsigned<64>, unsigned char);
+        extern unsigned<64> fmul_d(unsigned<64>, unsigned<64>, unsigned char);
+        extern unsigned<64> fdiv_d(unsigned<64>, unsigned<64>, unsigned char);
+        extern unsigned<64> fmadd_d(unsigned<64>, unsigned<64>, unsigned<64>, unsigned<32>, unsigned char);
+        extern unsigned<64> fsel_d(unsigned<64>, unsigned<64>, unsigned<32>);
+        extern unsigned<64> fsqrt_d(unsigned<64>, unsigned char);
+        extern unsigned<64> fcmp_d(unsigned<64>, unsigned<64>, unsigned<32>);
+        extern unsigned<64> fcvt_d(unsigned<64>, unsigned<32>, unsigned char);
+        extern unsigned<32> fconv_d2f(unsigned<64>, unsigned char);
+        extern unsigned<64> fconv_f2d(unsigned<32>, unsigned char);
+        extern unsigned<64> unbox_d(unsigned<64>);
+        extern unsigned<64> fclass_d(unsigned<64>);
     }
 
     instructions {

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -190,10 +190,7 @@ InstructionSet RV32D extends RV32F {
             encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
             args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                unsigned<64> ONE = 1;
-                unsigned<64> MSK1 = ONE<<63;
-                unsigned<64> MSK2 = MSK1-1;
-                unsigned<64> res = ((unsigned<64>)F[rs1] & MSK2) | ((unsigned<64>)F[rs2] & MSK1);
+                unsigned<64> res = F[rs2][63:63] :: F[rs1][62:0];
                 if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
@@ -206,10 +203,7 @@ InstructionSet RV32D extends RV32F {
             encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
             args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                unsigned<64> ONE = 1;
-                unsigned<64> MSK1 = ONE<<63;
-                unsigned<64> MSK2 = MSK1-1;
-                unsigned<64> res = ((unsigned<64>)F[rs1] & MSK2) | (~(unsigned<64>)F[rs2] & MSK1);
+                unsigned<64> res = ~F[rs2][63:63] :: F[rs1][62:0];
                 if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
@@ -222,9 +216,7 @@ InstructionSet RV32D extends RV32F {
             encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
             args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                unsigned<64> ONE = 1;
-                unsigned<64> MSK1 = ONE<<63;
-                unsigned<64> res = (unsigned<64>)F[rs1] ^ ((unsigned<64>)F[rs2] & MSK1);
+                unsigned<64> res = (unsigned<64>)F[rs1] ^ ((unsigned<64>)F[rs2] & (1 << 63));
                 if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
@@ -271,7 +263,7 @@ InstructionSet RV32D extends RV32F {
             behavior: {
                 unsigned<32> res = fconv_d2f(F[rs1], rm);
                 // NaN boxing
-                F[rd] = (-1<<64) + res;
+                F[rd] = (-1 << 32) + res;
             }
         }
 
@@ -283,7 +275,7 @@ InstructionSet RV32D extends RV32F {
                 if (FLEN == 64) {
                     F[rd] = res;
                 } else {
-                    F[rd] = (-1<<64) + res;
+                    F[rd] = (-1 << 64) + res;
                 }
             }
         }

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -21,7 +21,7 @@ InstructionSet RV32D extends RV32F {
     instructions {
         FLD {
             encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0000111;
-            args_disass:"f {rd}, {imm}({name(rs1)})";
+            assembly:"f {rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
@@ -35,7 +35,7 @@ InstructionSet RV32D extends RV32F {
 
         FSD {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: imm[4:0] :: 0b0100111;
-            args_disass:"f {rs2}, {imm}({name(rs1)})";
+            assembly:"f {rs2}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 MEM[offs] = (unsigned<64>)F[rs2];
@@ -44,7 +44,7 @@ InstructionSet RV32D extends RV32F {
 
         FMADD_D {
             encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f + F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 0, rm<7? rm: (unsigned char)FCSR);
@@ -60,7 +60,7 @@ InstructionSet RV32D extends RV32F {
 
         FMSUB_D {
             encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000111;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f - F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 1, rm<7? rm: (unsigned char)FCSR);
@@ -76,7 +76,7 @@ InstructionSet RV32D extends RV32F {
 
         FNMADD_D {
             encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001111;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f + F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 2, rm<7? rm: (unsigned char)FCSR);
@@ -92,7 +92,7 @@ InstructionSet RV32D extends RV32F {
 
         FNMSUB_D {
             encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f - F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 3, rm<7? rm: (unsigned char)FCSR);
@@ -108,7 +108,7 @@ InstructionSet RV32D extends RV32F {
 
         FADD_D {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
                 unsigned<64> res = fadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -124,7 +124,7 @@ InstructionSet RV32D extends RV32F {
 
         FSUB_D {
             encoding: 0b0000101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
                 unsigned<64> res = fsub_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -140,7 +140,7 @@ InstructionSet RV32D extends RV32F {
 
         FMUL_D {
             encoding: 0b0001001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
                 unsigned<64> res = fmul_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -156,7 +156,7 @@ InstructionSet RV32D extends RV32F {
 
         FDIV_D {
             encoding: 0b0001101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
                 unsigned<64> res = fdiv_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -172,7 +172,7 @@ InstructionSet RV32D extends RV32F {
 
         FSQRT_D {
             encoding: 0b0101101 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //F[rd]f = sqrt(F[rs1]f);
                 unsigned<64> res = fsqrt_d((unsigned<64>)F[rs1], rm<7? rm: (unsigned char)FCSR);
@@ -188,7 +188,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJ_D {
             encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, f {rs1}, f {rs2}";
+            assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = F[rs2][63:63] :: F[rs1][62:0];
                 if (FLEN == 64)
@@ -201,7 +201,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJN_D {
             encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, f {rs1}, f {rs2}";
+            assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = ~F[rs2][63:63] :: F[rs1][62:0];
                 if (FLEN == 64)
@@ -214,7 +214,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJX_D {
             encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, f {rs1}, f {rs2}";
+            assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = (unsigned<64>)F[rs1] ^ ((unsigned<64>)F[rs2] & (1 << 63));
                 if (FLEN == 64)
@@ -227,7 +227,7 @@ InstructionSet RV32D extends RV32F {
 
         FMIN_D {
             encoding: 0b0010101 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, f {rs1}, f {rs2}";
+            assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
                 unsigned<64> res = fsel_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 0);
@@ -243,7 +243,7 @@ InstructionSet RV32D extends RV32F {
 
         FMAX_D {
             encoding: 0b0010101 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, f {rs1}, f {rs2}";
+            assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
                 unsigned<64> res = fsel_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 1);
@@ -259,7 +259,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_S_D {
             encoding: 0b0100000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, f {rs1}";
+            assembly:"{name(rm)}, f {rd}, f {rs1}";
             behavior: {
                 unsigned<32> res = fconv_d2f(F[rs1], rm);
                 // NaN boxing
@@ -269,7 +269,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_S {
             encoding: 0b0100001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, f {rs1}";
+            assembly:"{name(rm)}, f {rd}, f {rs1}";
             behavior: {
                 unsigned<64> res = fconv_f2d((unsigned)F[rs1], rm);
                 if (FLEN == 64) {
@@ -282,7 +282,7 @@ InstructionSet RV32D extends RV32F {
 
         FEQ_D {
             encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 0);
                 unsigned<32> flags = fget_flags();
@@ -292,7 +292,7 @@ InstructionSet RV32D extends RV32F {
 
         FLT_D {
             encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 2);
                 unsigned<32> flags = fget_flags();
@@ -302,7 +302,7 @@ InstructionSet RV32D extends RV32F {
 
         FLE_D {
             encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 1);
                 unsigned<32> flags = fget_flags();
@@ -312,7 +312,7 @@ InstructionSet RV32D extends RV32F {
 
         FCLASS_D {
             encoding: 0b1110001 :: 0b00000 :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f {rs1}";
+            assembly:"{name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = fclass_d((unsigned<64>)F[rs1]);
             }
@@ -320,7 +320,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_W_D {
             encoding: 0b1100001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = fcvt_64_32((unsigned<64>)F[rs1], 0, rm);
                 unsigned<32> flags = fget_flags();
@@ -330,7 +330,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_WU_D {
             encoding: 0b1100001 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //FIXME: should be zext accodring to spec but needs to be sext according to tests
                 X[rd] = fcvt_64_32((unsigned<64>)F[rs1], 1, rm);
@@ -341,7 +341,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_W {
             encoding: 0b1101001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<64> res = fcvt_32_64((unsigned)X[rs1], 2, rm);
                 if (FLEN == 64)
@@ -354,7 +354,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_WU {
             encoding: 0b1101001 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<64> res = fcvt_32_64((unsigned)X[rs1], 3, rm);
                 if (FLEN == 64)
@@ -371,7 +371,7 @@ InstructionSet RV64D extends RV32D {
     instructions {
         FCVT_L_D {
             encoding: 0b1100001 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = fcvt_d((unsigned<64>)F[rs1], 0, rm);
                 unsigned<32> flags = fget_flags();
@@ -381,7 +381,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_LU_D {
             encoding: 0b1100001 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = fcvt_d((unsigned<64>)F[rs1], 1, rm);
                 unsigned<32> flags = fget_flags();
@@ -391,7 +391,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_D_L {
             encoding: 0b1101001 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<64> res = fcvt_d(X[rs1], 2, rm);
                 if (FLEN == 64)
@@ -404,7 +404,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_D_LU {
             encoding: 0b1101001 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<64> res = fcvt_d(X[rs1], 3, rm);
                 if (FLEN == 64)
@@ -417,7 +417,7 @@ InstructionSet RV64D extends RV32D {
 
         FMV_X_D {
             encoding: 0b1110001 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f {rs1}";
+            assembly:"{name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = F[rs1]; //FIXME: sign extend
             }
@@ -425,7 +425,7 @@ InstructionSet RV64D extends RV32D {
 
         FMV_D_X {
             encoding: 0b1111001 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, {name(rs1)}";
+            assembly:"f {rd}, {name(rs1)}";
             behavior: {
                 F[rd] = X[rs1];
             }

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -38,7 +38,7 @@ InstructionSet RV32D extends RV32F {
             args_disass:"f {rs2}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
-                MEM[offs] = F[rs2];
+                MEM[offs] = (unsigned<64>)F[rs2];
             }
         }
 

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -1,423 +1,442 @@
-import "RISCVBase.core_desc"
+import "RVF.core_desc"
 
 // TODO: review instruction description wrt. Spec after type system is fixed
-InstructionSet RV32D extends RISCVBase{
-    architectural_state {
-        unsigned FLEN;
-        unsigned FFLAG_MASK = 0x1f;
-
-	   	unsigned<FLEN> F[32];
-       	unsigned<32> FCSR;
-    }    
+InstructionSet RV32D extends RV32F {
     functions {
-        extern unsigned fadd_d(unsigned, unsigned, unsigned char);
-        extern unsigned fsub_d(unsigned, unsigned, unsigned char);
-        extern unsigned fmul_d(unsigned, unsigned, unsigned char);
-        extern unsigned fdiv_d(unsigned, unsigned, unsigned char);
-        extern unsigned fmadd_d(unsigned, unsigned, unsigned, unsigned, unsigned char);
-        extern unsigned fsel_d(unsigned, unsigned, unsigned);
-        extern unsigned fsqrt_d(unsigned, unsigned char);
-        extern unsigned fcmp_d(unsigned, unsigned, unsigned);
-        extern unsigned fcvt_d(unsigned, unsigned, unsigned char);
-        extern unsigned fconv_d2f(unsigned long);
-        extern unsigned long fconv_f2d(unsigned);
-        extern unsigned long fcvt_32_64(unsigned, unsigned, unsigned char);
-        extern unsigned long fcvt_64_32(unsigned, unsigned, unsigned char);
-        extern unsigned unbox_d(unsigned long);
-        extern unsigned fclass_d(unsigned);
-        extern unsigned fget_flags();
+        extern unsigned<32> fadd_d(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fsub_d(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fmul_d(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fdiv_d(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fmadd_d(unsigned<32>, unsigned<32>, unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fsel_d(unsigned<32>, unsigned<32>, unsigned<32>);
+        extern unsigned<32> fsqrt_d(unsigned<32>, unsigned char);
+        extern unsigned<32> fcmp_d(unsigned<32>, unsigned<32>, unsigned<32>);
+        extern unsigned<32> fcvt_d(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fconv_d2f(unsigned<64>);
+        extern unsigned<64> fconv_f2d(unsigned<32>);
+        extern unsigned<32> unbox_d(unsigned<64>);
+        extern unsigned<32> fclass_d(unsigned<32>);
     }
-    instructions{
+
+    instructions {
         FLD {
             encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0000111;
-            args_disass:"f{rd}, {imm}({name(rs1)})";
+            args_disass:"f {rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
-                unsigned long res = MEM[offs];
-                if(FLEN==64)
+                unsigned<64> res = MEM[offs];
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
                     F[rd] = (-1<<64) + res;
                 }
             }
         }
+
         FSD {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: imm[4:0] :: 0b0100111;
-            args_disass:"f{rs2}, {imm}({name(rs1)})";
+            args_disass:"f {rs2}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
-                MEM[offs]=F[rs2];
+                MEM[offs] = F[rs2];
             }
         }
+
         FMADD_D {
             encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
-                //F[rd]f= F[rs1]f * F[rs2]f + F[rs3]f;
-                unsigned long res = fmadd_d((unsigned long)F[rs1], (unsigned long)F[rs2], (unsigned long)F[rs3], 0U, rm<7? rm: (unsigned char)FCSR);
-                if(FLEN==64)
+                //F[rd]f = F[rs1]f * F[rs2]f + F[rs3]f;
+                unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 0, rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FMSUB_D {
             encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000111;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
-                //F[rd]f=F[rs1]f * F[rs2]f - F[rs3]f;
-                unsigned long res = fmadd_d((unsigned long)F[rs1], (unsigned long)F[rs2], (unsigned long)F[rs3], 1U, rm<7? rm: (unsigned char)FCSR);
-                if(FLEN==64)
+                //F[rd]f = F[rs1]f * F[rs2]f - F[rs3]f;
+                unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 1, rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FNMADD_D {
             encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001111;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
-                //F[rd]f=-F[rs1]f * F[rs2]f + F[rs3]f;
-                unsigned long res = fmadd_d((unsigned long)F[rs1], (unsigned long)F[rs2], (unsigned long)F[rs3], 2U, rm<7? rm: (unsigned char)FCSR);
-                if(FLEN==64)
+                //F[rd]f = -F[rs1]f * F[rs2]f + F[rs3]f;
+                unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 2, rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FNMSUB_D {
             encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
-                //F[rd]f=-F[rs1]f * F[rs2]f - F[rs3]f;
-                unsigned long res = fmadd_d((unsigned long)F[rs1], (unsigned long)F[rs2], (unsigned long)F[rs3], 3U, rm<7? rm: (unsigned char)FCSR);
-                if(FLEN==64)
+                //F[rd]f = -F[rs1]f * F[rs2]f - F[rs3]f;
+                unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 3, rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FADD_D {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
-                unsigned long res = fadd_d((unsigned long)F[rs1], (unsigned long)F[rs2], rm<7? rm: (unsigned char)FCSR);
-                if(FLEN==64)
+                unsigned<64> res = fadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FSUB_D {
             encoding: 0b0000101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
-                unsigned long res = fsub_d((unsigned long)F[rs1], (unsigned long)F[rs2], rm<7? rm: (unsigned char)FCSR);
-                if(FLEN==64)
+                unsigned<64> res = fsub_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FMUL_D {
             encoding: 0b0001001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
-                unsigned long res = fmul_d((unsigned long)F[rs1], (unsigned long)F[rs2], rm<7? rm: (unsigned char)FCSR);
-                if(FLEN==64)
+                unsigned<64> res = fmul_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FDIV_D {
             encoding: 0b0001101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
-                unsigned long res = fdiv_d((unsigned long)F[rs1], (unsigned long)F[rs2], rm<7? rm: (unsigned char)FCSR);
-                if(FLEN==64)
+                unsigned<64> res = fdiv_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FSQRT_D {
             encoding: 0b0101101 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
-                //F[rd]f=sqrt(F[rs1]f);
-                unsigned long res = fsqrt_d((unsigned long)F[rs1], rm<7? rm: (unsigned char)FCSR);
-                if(FLEN==64)
+                //F[rd]f = sqrt(F[rs1]f);
+                unsigned<64> res = fsqrt_d((unsigned<64>)F[rs1], rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FSGNJ_D {
             encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                unsigned long ONE = 1;
-                unsigned long MSK1 = ONE<<63;
-                unsigned long MSK2 = MSK1-1;
-                unsigned long res = ((unsigned long)F[rs1] & MSK2) | ((unsigned long)F[rs2] & MSK1);
-                if(FLEN==64)
+                unsigned<64> ONE = 1;
+                unsigned<64> MSK1 = ONE<<63;
+                unsigned<64> MSK2 = MSK1-1;
+                unsigned<64> res = ((unsigned<64>)F[rs1] & MSK2) | ((unsigned<64>)F[rs2] & MSK1);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
             }
         }
+
         FSGNJN_D {
             encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                unsigned long ONE = 1;
-                unsigned long MSK1 = ONE<<63;
-                unsigned long MSK2 = MSK1-1;
-                unsigned long res = ((unsigned long)F[rs1] & MSK2) | (~(unsigned long)F[rs2] & MSK1);
-                if(FLEN==64)
+                unsigned<64> ONE = 1;
+                unsigned<64> MSK1 = ONE<<63;
+                unsigned<64> MSK2 = MSK1-1;
+                unsigned<64> res = ((unsigned<64>)F[rs1] & MSK2) | (~(unsigned<64>)F[rs2] & MSK1);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
             }
         }
+
         FSGNJX_D {
             encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                unsigned long ONE = 1;
-                unsigned long MSK1 = ONE<<63;
-                unsigned long res = (unsigned long)F[rs1] ^ ((unsigned long)F[rs2] & MSK1);
-                if(FLEN==64)
+                unsigned<64> ONE = 1;
+                unsigned<64> MSK1 = ONE<<63;
+                unsigned<64> res = (unsigned<64>)F[rs1] ^ ((unsigned<64>)F[rs2] & MSK1);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
             }
         }
-        FMIN_D  {
+
+        FMIN_D {
             encoding: 0b0010101 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                //F[rd]f= choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
-                unsigned long res = fsel_d((unsigned long)F[rs1], (unsigned long)F[rs2], 0U);
-                if(FLEN==64)
+                //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
+                unsigned<64> res = fsel_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 0);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FMAX_D {
             encoding: 0b0010101 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                //F[rd]f= choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
-                unsigned long res = fsel_d((unsigned long)F[rs1], (unsigned long)F[rs2], 1U);
-                if(FLEN==64)
+                //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
+                unsigned<64> res = fsel_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 1);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FCVT_S_D {
             encoding: 0b0100000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}";
+            args_disass:"{name(rm)}, f {rd}, f {rs1}";
             behavior: {
-                unsigned res = fconv_d2f(F[rs1], rm);
+                unsigned<32> res = fconv_d2f(F[rs1], rm);
                 // NaN boxing
-                F[rd] = (-1LL<<64) + res;
+                F[rd] = (-1<<64) + res;
             }
         }
+
         FCVT_D_S {
             encoding: 0b0100001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}";
+            args_disass:"{name(rm)}, f {rd}, f {rs1}";
             behavior: {
-                unsigned long res = fconv_f2d((unsigned)F[rs1], rm);
-                if(FLEN==64){
+                unsigned<64> res = fconv_f2d((unsigned)F[rs1], rm);
+                if (FLEN == 64) {
                     F[rd] = res;
                 } else {
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
             }
         }
+
         FEQ_D {
             encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
-                X[rd]=fcmp_d((unsigned long)F[rs1], (unsigned long)F[rs2], 0U);
-                unsigned flags = fget_flags();
+                X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 0);
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FLT_D {
             encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
-                X[rd]=fcmp_d((unsigned long)F[rs1], (unsigned long)F[rs2], 2U);
-                unsigned flags = fget_flags();
+                X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 2);
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FLE_D {
             encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
-                X[rd]=fcmp_d((unsigned long)F[rs1], (unsigned long)F[rs2], 1U);
-                unsigned flags = fget_flags();
+                X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 1);
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FCLASS_D {
             encoding: 0b1110001 :: 0b00000 :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}";
+            args_disass:"{name(rd)}, f {rs1}";
             behavior: {
-                X[rd]=fclass_d((unsigned long)F[rs1]);
+                X[rd] = fclass_d((unsigned<64>)F[rs1]);
             }
         }
+
         FCVT_W_D {
             encoding: 0b1100001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
-                X[rd]= fcvt_64_32((unsigned long)F[rs1], 0U, rm);
-                unsigned flags = fget_flags();
+                X[rd] = fcvt_64_32((unsigned<64>)F[rs1], 0, rm);
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FCVT_WU_D {
             encoding: 0b1100001 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //FIXME: should be zext accodring to spec but needs to be sext according to tests
-                X[rd]= fcvt_64_32((unsigned long)F[rs1], 1U, rm);
-                unsigned flags = fget_flags();
+                X[rd] = fcvt_64_32((unsigned<64>)F[rs1], 1, rm);
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FCVT_D_W {
             encoding: 0b1101001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned long res = fcvt_32_64((unsigned)X[rs1], 2U, rm);
-                if(FLEN==64)
+                unsigned<64> res = fcvt_32_64((unsigned)X[rs1], 2, rm);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
             }
         }
+
         FCVT_D_WU {
             encoding: 0b1101001 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned long res =fcvt_32_64((unsigned)X[rs1], 3U, rm);
-                if(FLEN==64)
+                unsigned<64> res = fcvt_32_64((unsigned)X[rs1], 3, rm);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
             }
         }
     }
 }
-InstructionSet RV64D extends RV32D{
 
-    instructions{
+InstructionSet RV64D extends RV32D {
+    instructions {
         FCVT_L_D {
             encoding: 0b1100001 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
-                X[rd]= fcvt_d((unsigned long)F[rs1], 0U, rm);
-                unsigned flags = fget_flags();
+                X[rd] = fcvt_d((unsigned<64>)F[rs1], 0, rm);
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FCVT_LU_D {
             encoding: 0b1100001 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
-                X[rd]= fcvt_d((unsigned long)F[rs1], 1U, rm);
-                unsigned flags = fget_flags();
+                X[rd] = fcvt_d((unsigned<64>)F[rs1], 1, rm);
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FCVT_D_L {
             encoding: 0b1101001 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned long res = fcvt_d(X[rs1], 2U, rm);
-                if(FLEN==64)
+                unsigned<64> res = fcvt_d(X[rs1], 2, rm);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
             }
         }
+
         FCVT_D_LU {
             encoding: 0b1101001 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned long res =fcvt_d(X[rs1], 3U, rm);
-                if(FLEN==64)
+                unsigned<64> res = fcvt_d(X[rs1], 3, rm);
+                if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1LL<<64) + res;
+                    F[rd] = (-1<<64) + res;
                 }
             }
         }
+
         FMV_X_D {
             encoding: 0b1110001 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}";
+            args_disass:"{name(rd)}, f {rs1}";
             behavior: {
-                X[rd]=F[rs1]; //FIXME: sign extend
+                X[rd] = F[rs1]; //FIXME: sign extend
             }
         }
+
         FMV_D_X {
             encoding: 0b1111001 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, {name(rs1)}";
+            args_disass:"f {rd}, {name(rs1)}";
             behavior: {
                 F[rd] = X[rs1];
             }
         }
     }
 }
-    
-    

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -24,7 +24,7 @@ InstructionSet RV32D extends RV32F {
             args_disass:"f {rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
-                unsigned<64> res = MEM[offs];
+                unsigned<64> res = (unsigned<64>)MEM[offs];
                 if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -2,6 +2,10 @@ import "RVF.core_desc"
 
 // TODO: review instruction description wrt. Spec after type system is fixed
 InstructionSet RV32D extends RV32F {
+    architectural_state {
+        FLEN = 64;
+    }
+
     functions {
         extern unsigned<32> fadd_d(unsigned<32>, unsigned<32>, unsigned char);
         extern unsigned<32> fsub_d(unsigned<32>, unsigned<32>, unsigned char);

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -288,7 +288,15 @@ InstructionSet RV32D extends RV32F {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
-                X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 0);
+                unsigned<64> res = 0;
+                if (FLEN == 64)
+                    res = fcmp_d(F[rs1], F[rs2], 0);
+                else {
+                    unsigned<64> frs1 = unbox_d(F[rs1]);
+                    unsigned<64> frs2 = unbox_d(F[rs2]);
+                    res = fcmp_d(frs1, frs2, 0);
+                }
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -298,7 +306,15 @@ InstructionSet RV32D extends RV32F {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
-                X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 2);
+                unsigned<64> res = 0;
+                if (FLEN == 64)
+                    res = fcmp_d(F[rs1], F[rs2], 2);
+                else {
+                    unsigned<64> frs1 = unbox_d(F[rs1]);
+                    unsigned<64> frs2 = unbox_d(F[rs2]);
+                    res = fcmp_d(frs1, frs2, 2);
+                }
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -308,7 +324,15 @@ InstructionSet RV32D extends RV32F {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
-                X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 1);
+                unsigned<64> res = 0;
+                if (FLEN == 64)
+                    res = fcmp_d(F[rs1], F[rs2], 1);
+                else {
+                    unsigned<64> frs1 = unbox_d(F[rs1]);
+                    unsigned<64> frs2 = unbox_d(F[rs2]);
+                    res = fcmp_d(frs1, frs2, 1);
+                }
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -318,7 +342,7 @@ InstructionSet RV32D extends RV32F {
             encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}";
             behavior: {
-                X[rd] = fclass_d((unsigned<64>)F[rs1]);
+                X[rd % RFS] = fclass_d((unsigned<64>)F[rs1]);
             }
         }
 
@@ -326,7 +350,14 @@ InstructionSet RV32D extends RV32F {
             encoding: 7'b1100001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
-                X[rd] = fcvt_64_32((unsigned<64>)F[rs1], 0, rm);
+                signed<64> res = 0;
+                if (FLEN == 64)
+                    res = fcvt_64_32(F[rs1], 0, rm);
+                else { // NaN boxing
+                    unsigned<64> frs1 = unbox_d(F[rs1]);
+                    res = fcvt_64_32(frs1, 0, rm);
+                }
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -337,7 +368,14 @@ InstructionSet RV32D extends RV32F {
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //FIXME: should be zext accodring to spec but needs to be sext according to tests
-                X[rd] = fcvt_64_32((unsigned<64>)F[rs1], 1, rm);
+                unsigned<64> res = 0;
+                if (FLEN == 64)
+                    res = fcvt_64_32(F[rs1], 0, rm);
+                else { // NaN boxing
+                    unsigned<64> frs1 = unbox_d(F[rs1]);
+                    res = fcvt_64_32(frs1, 0, rm);
+                }
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -23,7 +23,7 @@ InstructionSet RV32D extends RV32F {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0000111;
             assembly:"f {rd}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
                 if (FLEN == 64)
                     F[rd] = res;
@@ -37,7 +37,7 @@ InstructionSet RV32D extends RV32F {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: imm[4:0] :: 7'b0100111;
             assembly:"f {rs2}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 MEM[offs] = (unsigned<64>)F[rs2];
             }
         }
@@ -343,7 +343,7 @@ InstructionSet RV32D extends RV32F {
             encoding: 7'b1101001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned<64> res = fcvt_32_64((unsigned)X[rs1], 2, rm);
+                signed<64> res = fcvt_32_64((unsigned)X[rs1 % RFS], 2, rm);
                 if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
@@ -356,7 +356,7 @@ InstructionSet RV32D extends RV32F {
             encoding: 7'b1101001 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned<64> res = fcvt_32_64((unsigned)X[rs1], 3, rm);
+                unsigned<64> res = fcvt_32_64((unsigned)X[rs1 % RFS], 3, rm);
                 if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
@@ -373,7 +373,7 @@ InstructionSet RV64D extends RV32D {
             encoding: 7'b1100001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
-                X[rd] = fcvt_d((unsigned<64>)F[rs1], 0, rm);
+                X[rd % RFS] = fcvt_d((unsigned<64>)F[rs1], 0, rm);
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -383,7 +383,7 @@ InstructionSet RV64D extends RV32D {
             encoding: 7'b1100001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
-                X[rd] = fcvt_d((unsigned<64>)F[rs1], 1, rm);
+                X[rd % RFS] = fcvt_d((unsigned<64>)F[rs1], 1, rm);
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -393,7 +393,7 @@ InstructionSet RV64D extends RV32D {
             encoding: 7'b1101001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned<64> res = fcvt_d(X[rs1], 2, rm);
+                unsigned<64> res = fcvt_d(X[rs1 % RFS], 2, rm);
                 if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
@@ -406,7 +406,7 @@ InstructionSet RV64D extends RV32D {
             encoding: 7'b1101001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned<64> res = fcvt_d(X[rs1], 3, rm);
+                unsigned<64> res = fcvt_d(X[rs1 % RFS], 3, rm);
                 if (FLEN == 64)
                     F[rd] = res;
                 else { // NaN boxing
@@ -419,7 +419,7 @@ InstructionSet RV64D extends RV32D {
             encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}";
             behavior: {
-                X[rd] = F[rs1]; //FIXME: sign extend
+                X[rd % RFS] = F[rs1]; //FIXME: sign extend
             }
         }
 
@@ -427,7 +427,7 @@ InstructionSet RV64D extends RV32D {
             encoding: 7'b1111001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, {name(rs1)}";
             behavior: {
-                F[rd] = X[rs1];
+                F[rd] = X[rs1 % RFS];
             }
         }
     }

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -20,7 +20,7 @@ InstructionSet RV32D extends RV32F {
 
     instructions {
         FLD {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0000111;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0000111;
             assembly:"f {rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
@@ -34,7 +34,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FSD {
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b011 :: imm[4:0] :: 0b0100111;
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: imm[4:0] :: 7'b0100111;
             assembly:"f {rs2}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
@@ -43,7 +43,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FMADD_D {
-            encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000011;
+            encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f + F[rs3]f;
@@ -59,7 +59,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FMSUB_D {
-            encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000111;
+            encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000111;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f - F[rs3]f;
@@ -75,7 +75,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FNMADD_D {
-            encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001111;
+            encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001111;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f + F[rs3]f;
@@ -91,7 +91,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FNMSUB_D {
-            encoding: rs3[4:0] :: 0b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001011;
+            encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f - F[rs3]f;
@@ -107,7 +107,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FADD_D {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
@@ -123,7 +123,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FSUB_D {
-            encoding: 0b0000101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0000101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
@@ -139,7 +139,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FMUL_D {
-            encoding: 0b0001001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0001001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
@@ -155,7 +155,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FDIV_D {
-            encoding: 0b0001101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0001101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
@@ -171,7 +171,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FSQRT_D {
-            encoding: 0b0101101 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0101101 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //F[rd]f = sqrt(F[rs1]f);
@@ -187,7 +187,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FSGNJ_D {
-            encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = F[rs2][63:63] :: F[rs1][62:0];
@@ -200,7 +200,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FSGNJN_D {
-            encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = ~F[rs2][63:63] :: F[rs1][62:0];
@@ -213,7 +213,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FSGNJX_D {
-            encoding: 0b0010001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = (unsigned<64>)F[rs1] ^ ((unsigned<64>)F[rs2] & (1 << 63));
@@ -226,7 +226,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FMIN_D {
-            encoding: 0b0010101 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0010101 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
@@ -242,7 +242,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FMAX_D {
-            encoding: 0b0010101 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0010101 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
@@ -258,7 +258,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FCVT_S_D {
-            encoding: 0b0100000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0100000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, f {rs1}";
             behavior: {
                 unsigned<32> res = fconv_d2f(F[rs1], rm);
@@ -268,7 +268,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FCVT_D_S {
-            encoding: 0b0100001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0100001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, f {rs1}";
             behavior: {
                 unsigned<64> res = fconv_f2d((unsigned)F[rs1], rm);
@@ -281,7 +281,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FEQ_D {
-            encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 0);
@@ -291,7 +291,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FLT_D {
-            encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 2);
@@ -301,7 +301,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FLE_D {
-            encoding: 0b1010001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 X[rd] = fcmp_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 1);
@@ -311,7 +311,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FCLASS_D {
-            encoding: 0b1110001 :: 0b00000 :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = fclass_d((unsigned<64>)F[rs1]);
@@ -319,7 +319,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FCVT_W_D {
-            encoding: 0b1100001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1100001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = fcvt_64_32((unsigned<64>)F[rs1], 0, rm);
@@ -329,7 +329,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FCVT_WU_D {
-            encoding: 0b1100001 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1100001 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //FIXME: should be zext accodring to spec but needs to be sext according to tests
@@ -340,7 +340,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FCVT_D_W {
-            encoding: 0b1101001 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1101001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<64> res = fcvt_32_64((unsigned)X[rs1], 2, rm);
@@ -353,7 +353,7 @@ InstructionSet RV32D extends RV32F {
         }
 
         FCVT_D_WU {
-            encoding: 0b1101001 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1101001 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<64> res = fcvt_32_64((unsigned)X[rs1], 3, rm);
@@ -370,7 +370,7 @@ InstructionSet RV32D extends RV32F {
 InstructionSet RV64D extends RV32D {
     instructions {
         FCVT_L_D {
-            encoding: 0b1100001 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1100001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = fcvt_d((unsigned<64>)F[rs1], 0, rm);
@@ -380,7 +380,7 @@ InstructionSet RV64D extends RV32D {
         }
 
         FCVT_LU_D {
-            encoding: 0b1100001 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1100001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = fcvt_d((unsigned<64>)F[rs1], 1, rm);
@@ -390,7 +390,7 @@ InstructionSet RV64D extends RV32D {
         }
 
         FCVT_D_L {
-            encoding: 0b1101001 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1101001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<64> res = fcvt_d(X[rs1], 2, rm);
@@ -403,7 +403,7 @@ InstructionSet RV64D extends RV32D {
         }
 
         FCVT_D_LU {
-            encoding: 0b1101001 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1101001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<64> res = fcvt_d(X[rs1], 3, rm);
@@ -416,7 +416,7 @@ InstructionSet RV64D extends RV32D {
         }
 
         FMV_X_D {
-            encoding: 0b1110001 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = F[rs1]; //FIXME: sign extend
@@ -424,7 +424,7 @@ InstructionSet RV64D extends RV32D {
         }
 
         FMV_D_X {
-            encoding: 0b1111001 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1111001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, {name(rs1)}";
             behavior: {
                 F[rd] = X[rs1];

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -47,7 +47,7 @@ InstructionSet RV32F extends Zicsr {
             args_disass:"f {rs2}, {imm}({name(rs1)])";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
-                MEM[offs] = F[rs2];
+                MEM[offs] = (unsigned<32>)F[rs2];
             }
         }
 

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -1,452 +1,480 @@
 import "RV32I.core_desc"
 
 // TODO: review instruction description wrt. Spec after type system is fixed
-InstructionSet RV32F extends RV32I{
+InstructionSet RV32F extends Zicsr {
     architectural_state {
-        unsigned FLEN;
-        unsigned FFLAG_MASK = 0x1f;
+        unsigned<32> FLEN;
+        unsigned<32> FFLAG_MASK = 0x1f;
 
-	   	unsigned<FLEN> F[32];
-       	unsigned<32> FCSR;
-    }    
-    functions {
-        extern unsigned fadd_s(unsigned, unsigned, unsigned char);
-        extern unsigned fsub_s(unsigned, unsigned, unsigned char);
-        extern unsigned fmul_s(unsigned, unsigned, unsigned char);
-        extern unsigned fdiv_s(unsigned, unsigned, unsigned char);
-        extern unsigned fmadd_s(unsigned, unsigned, unsigned, unsigned, unsigned char);
-        extern unsigned fsel_s(unsigned, unsigned, unsigned);
-        extern unsigned fsqrt_s(unsigned, unsigned char);
-        extern unsigned fcmp_s(unsigned, unsigned, unsigned);
-        extern unsigned fcvt_s(unsigned, unsigned, unsigned char);
-        extern unsigned long fcvt_32_64(unsigned, unsigned, unsigned char);
-        extern unsigned long fcvt_64_32(unsigned, unsigned, unsigned char);
-        extern unsigned unbox_s(unsigned long);
-        extern unsigned fclass_s(unsigned);
-        extern unsigned fget_flags();
+        register unsigned<FLEN> F[32];
+        unsigned<32>& FCSR = CSR[3];
     }
-    instructions{
+
+    functions {
+        extern unsigned<32> fadd_s(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fsub_s(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fmul_s(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fdiv_s(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fmadd_s(unsigned<32>, unsigned<32>, unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fsel_s(unsigned<32>, unsigned<32>, unsigned<32>);
+        extern unsigned<32> fsqrt_s(unsigned<32>, unsigned char);
+        extern unsigned<32> fcmp_s(unsigned<32>, unsigned<32>, unsigned<32>);
+        extern unsigned<32> fcvt_s(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<64> fcvt_32_64(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<64> fcvt_64_32(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> unbox_s(unsigned<64>);
+        extern unsigned<32> fclass_s(unsigned<32>);
+        extern unsigned<32> fget_flags();
+    }
+
+    instructions {
         FLW {
             encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0000111;
-            args_disass:"f{rd}, {imm}({name(rs1)})";
+            args_disass:"f {rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 unsigned<XLEN> res = MEM[offs];
-                if(FLEN==32)
+                if (FLEN == 32)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }
+
         FSW {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: imm[4:0] :: 0b0100111;
-            args_disass:"f{rs2}, {imm}({name(rs1)])";
+            args_disass:"f {rs2}, {imm}({name(rs1)])";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
-                MEM[offs]=F[rs2];
+                MEM[offs] = F[rs2];
             }
         }
+
         FMADD_S {
             encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
-                //F[rd]f= F[rs1]f * F[rs2]f + F[rs3]f;
-                if(FLEN==32)
-    	            F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 0, rm<7? (unsigned char)rm:(unsigned char)FCSR);
+                //F[rd]f = F[rs1]f * F[rs2]f + F[rs3]f;
+                if (FLEN == 32)
+                    F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 0, rm<7? (unsigned char)rm:(unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned res = fmadd_s(unbox_s(F[rs1]), unbox_s(F[rs2]), unbox_s(F[rs3]), 0, rm<7? rm: (unsigned char)FCSR);            
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> res = fmadd_s(unbox_s(F[rs1]), unbox_s(F[rs2]), unbox_s(F[rs3]), 0, rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FMSUB_S {
             encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000111;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
-                //F[rd]f=F[rs1]f * F[rs2]f - F[rs3]f;
-                if(FLEN==32)
-    	            F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 1UL, rm<7? rm: (unsigned char)FCSR);
+                //F[rd]f = F[rs1]f * F[rs2]f - F[rs3]f;
+                if (FLEN == 32)
+                    F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 1, rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-                    unsigned res = fmadd_s(unbox_s(F[rs1]), unbox_s(F[rs2]), unbox_s(F[rs3]), 1U, rm<7? rm: (unsigned char)FCSR);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> res = fmadd_s(unbox_s(F[rs1]), unbox_s(F[rs2]), unbox_s(F[rs3]), 1, rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FNMADD_S {
             encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001111;
-            args_disass:"{name(rm)}, name(rd), f{rs1}, f{rs2}, f{rs3}";
+            args_disass:"{name(rm)}, name(rd), f {rs1}, f {rs2}, f {rs3}";
             behavior: {
-                //F[rd]f=-F[rs1]f * F[rs2]f + F[rs3]f;
-                if(FLEN==32)
-                    F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 2U, rm<7? rm: (unsigned char)FCSR);
+                //F[rd]f = -F[rs1]f * F[rs2]f + F[rs3]f;
+                if (FLEN == 32)
+                    F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 2, rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-    	            unsigned frs3 = unbox_s(F[rs3]);
-                    unsigned res = fmadd_s(frs1, frs2, frs3, 2U, rm<7? rm: (unsigned char)FCSR);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    unsigned<32> frs3 = unbox_s(F[rs3]);
+                    unsigned<32> res = fmadd_s(frs1, frs2, frs3, 2, rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FNMSUB_S {
             encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}, f{rs2}, f{rs3}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
-            //F[rd]f=-F[rs1]f * F[rs2]f - F[rs3]f;
-                if(FLEN==32)
-    	            F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 3U, rm<7? rm: (unsigned char)FCSR);
+            //F[rd]f = -F[rs1]f * F[rs2]f - F[rs3]f;
+                if (FLEN == 32)
+                    F[rd] = fmadd_s(F[rs1], F[rs2], F[rs3], 3, rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-    	            unsigned frs3 = unbox_s(F[rs3]);
-                    unsigned res = fmadd_s(frs1, frs2, frs3, 3U, rm<7? rm: (unsigned char)FCSR);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    unsigned<32> frs3 = unbox_s(F[rs3]);
+                    unsigned<32> res = fmadd_s(frs1, frs2, frs3, 3, rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FADD_S {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}, f{rs2}";
+            args_disass:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
-                if(FLEN==32)
-    	            F[rd] = fadd_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 32)
+                    F[rd] = fadd_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fadd_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    unsigned<32> res = fadd_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FSUB_S {
             encoding: 0b0000100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}, f{rs2}";
+            args_disass:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
-                if(FLEN==32)
-    	            F[rd] = fsub_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 32)
+                    F[rd] = fsub_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fsub_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    unsigned<32> res = fsub_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FMUL_S {
             encoding: 0b0001000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}, f{rs2}";
+            args_disass:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
-                if(FLEN==32)
-    	            F[rd] = fmul_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 32)
+                    F[rd] = fmul_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fmul_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    unsigned<32> res = fmul_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FDIV_S {
             encoding: 0b0001100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}, f{rs2}";
+            args_disass:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
-                if(FLEN==32)
-    	            F[rd] = fdiv_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
+                if (FLEN == 32)
+                    F[rd] = fdiv_s(F[rs1], F[rs2], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fdiv_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    unsigned<32> res = fdiv_s(frs1, frs2, rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FSQRT_S {
             encoding: 0b0101100 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, f{rs1}";
+            args_disass:"{name(rm)}, f {rd}, f {rs1}";
             behavior: {
-                //F[rd]f=sqrt(F[rs1]f);
-                if(FLEN==32)
-    	            F[rd] = fsqrt_s(F[rs1], rm<7? rm: (unsigned char)FCSR);
+                //F[rd]f = sqrt(F[rs1]f);
+                if (FLEN == 32)
+                    F[rd] = fsqrt_s(F[rs1], rm<7? rm: (unsigned char)FCSR);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-                    unsigned res = fsqrt_s(frs1, rm<7? rm: (unsigned char)FCSR);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> res = fsqrt_s(frs1, rm<7? rm: (unsigned char)FCSR);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FSGNJ_S {
             encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                if(FLEN==32)
-    	            F[rd] = (F[rs1] & 0x7fffffff) :: (F[rs2] & 0x80000000);
+                if (FLEN == 32)
+                    F[rd] = F[rs2][31] :: F[rs1][30:0];
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = (frs1 & 0x7fffffff) :: (frs2 & 0x80000000);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    unsigned<32> res = (frs1 & 0x7fffffff) :: (frs2 & 0x80000000);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }
+
         FSGNJN_S {
             encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                if(FLEN==32)
-    	            F[rd] = (F[rs1] & 0x7fffffff) :: (~F[rs2] & 0x80000000);
+                if (FLEN == 32)
+                    F[rd] = ~F[rs2][31:31] :: F[rs1][30:0];
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = (frs1 & 0x7fffffff) :: (~frs2 & 0x80000000);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    unsigned<32> res = (frs1 & 0x7fffffff) :: (~frs2 & 0x80000000);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }
+
         FSGNJX_S {
             encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                if(FLEN==32)
-    	            F[rd] = F[rs1] ^ (F[rs2] & 0x80000000);
+                if (FLEN == 32)
+                    F[rd] = F[rs1] ^ (F[rs2] & 0x80000000);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = frs1 ^ (frs2 & 0x80000000);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    unsigned<32> res = frs1 ^ (frs2 & 0x80000000);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }
-        FMIN_S  {
+
+        FMIN_S {
             encoding: 0b0010100 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                //F[rd]f= choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
-                if(FLEN==32)
-    	            F[rd] = fsel_s(F[rs1], F[rs2], 0U);
+                //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
+                if (FLEN == 32)
+                    F[rd] = fsel_s(F[rs1], F[rs2], 0);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fsel_s(frs1, frs2, 0U);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    unsigned<32> res = fsel_s(frs1, frs2, 0);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FMAX_S {
             encoding: 0b0010100 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, f{rs1}, f{rs2}";
+            args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
-                //F[rd]f= choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
-                if(FLEN==32)
-    	            F[rd] = fsel_s(F[rs1], F[rs2], 1U);
+                //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
+                if (FLEN == 32)
+                    F[rd] = fsel_s(F[rs1], F[rs2], 1);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-                    unsigned res = fsel_s(frs1, frs2, 1U);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    unsigned<32> res = fsel_s(frs1, frs2, 1);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FCVT_W_S {
             encoding: 0b1100000 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
-                if(FLEN==32)
-    	            X[rd] = fcvt_s(F[rs1], 0U, rm);
+                if (FLEN == 32)
+                    X[rd] = fcvt_s(F[rs1], 0, rm);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-                    X[rd]= fcvt_s(frs1, 0U, rm);
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    X[rd] = fcvt_s(frs1, 0, rm);
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FCVT_WU_S {
             encoding: 0b1100000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //FIXME: according to the spec it should be zero-extended not sign extended
-                if(FLEN==32)
-               		 X[rd]= fcvt_s(F[rs1], 1U, rm);
+                if (FLEN == 32)
+                      X[rd] = fcvt_s(F[rs1], 1, rm);
                 else { // NaN boxing
-    	            unsigned frs1 = unbox_s(F[rs1]);
-                    X[rd]= fcvt_s(frs1, 1U, rm);
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    X[rd] = fcvt_s(frs1, 1, rm);
                 }
-                unsigned flags = fget_flags();
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FEQ_S {
             encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
-                if(FLEN==32)
-    	            X[rd]=fcmp_s(F[rs1], F[rs2], 0U);
-    	        else {
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-    	            X[rd]=fcmp_s(frs1, frs2, 0U);	        
-    	        }
-                unsigned flags = fget_flags();
+                if (FLEN == 32)
+                    X[rd] = fcmp_s(F[rs1], F[rs2], 0);
+                else {
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    X[rd] = fcmp_s(frs1, frs2, 0);
+                }
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FLT_S {
             encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
-                if(FLEN==32)
-                	X[rd]=fcmp_s(F[rs1], F[rs2], 2U);
-    	        else {
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-                	X[rd]=fcmp_s(frs1, frs2, 2U);
+                if (FLEN == 32)
+                    X[rd] = fcmp_s(F[rs1], F[rs2], 2);
+                else {
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    X[rd] = fcmp_s(frs1, frs2, 2);
                 }
-                X[rd]=fcmp_s((unsigned)F[rs1], (unsigned)F[rs2], 2U);
-                unsigned flags = fget_flags();
+                X[rd] = fcmp_s((unsigned)F[rs1], (unsigned)F[rs2], 2);
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FLE_S {
             encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}, f{rs2}";
+            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
-                if(FLEN==32)
-    	            X[rd]=fcmp_s(F[rs1], F[rs2], 1U);
-    	        else {
-    	            unsigned frs1 = unbox_s(F[rs1]);
-    	            unsigned frs2 = unbox_s(F[rs2]);
-    	            X[rd]=fcmp_s(frs1, frs2, 1U);
-    	        }
-                unsigned flags = fget_flags();
+                if (FLEN == 32)
+                    X[rd] = fcmp_s(F[rs1], F[rs2], 1);
+                else {
+                    unsigned<32> frs1 = unbox_s(F[rs1]);
+                    unsigned<32> frs2 = unbox_s(F[rs2]);
+                    X[rd] = fcmp_s(frs1, frs2, 1);
+                }
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FCLASS_S {
             encoding: 0b1110000 :: 0b00000 :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}";
+            args_disass:"{name(rd)}, f {rs1}";
             behavior: {
-                X[rd]=fclass_s(unbox_s(F[rs1]));
+                X[rd] = fclass_s(unbox_s(F[rs1]));
             }
         }
+
         FCVT_S_W {
             encoding: 0b1101000 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                if(FLEN==32)
-    	            F[rd]  = fcvt_s((unsigned)X[rs1], 2U, rm);
+                if (FLEN == 32)
+                    F[rd] = fcvt_s((unsigned)X[rs1], 2, rm);
                 else { // NaN boxing
-                    unsigned res = fcvt_s((unsigned)X[rs1], 2U, rm);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> res = fcvt_s((unsigned)X[rs1], 2, rm);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }
+
         FCVT_S_WU {
             encoding: 0b1101000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                if(FLEN==32)
-        	        F[rd]  =fcvt_s((unsigned)X[rs1], 3U, rm);
+                if (FLEN == 32)
+                    F[rd] = fcvt_s((unsigned)X[rs1], 3, rm);
                 else { // NaN boxing
-                    unsigned res =fcvt_s((unsigned)X[rs1], 3U, rm);
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                    unsigned<32> res = fcvt_s((unsigned)X[rs1], 3, rm);
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }
+
         FMV_X_W {
             encoding: 0b1110000 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f{rs1}";
+            args_disass:"{name(rd)}, f {rs1}";
             behavior: {
-                X[rd]=F[rs1];
+                X[rd] = F[rs1];
             }
         }
+
         FMV_W_X {
             encoding: 0b1111000 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f{rd}, {name(rs1)}";
+            args_disass:"f {rd}, {name(rs1)}";
             behavior: {
-                if(FLEN==32)
+                if (FLEN == 32)
                     F[rd] = X[rs1];
                 else { // NaN boxing
-                    F[rd] = (-1<<32) | (unsigned<FLEN>)X[rs1];
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)X[rs1];
                 }
             }
         }
     }
 }
 
-InstructionSet RV64F extends RV32F{
-
-    instructions{
+InstructionSet RV64F extends RV32F {
+    instructions {
         FCVT_L_S { // fp to 64bit signed integer
             encoding: 0b1100000 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
-                unsigned long res = fcvt_32_64(unbox_s(F[rs1]), 0U, rm);
-                X[rd]= res;
-                unsigned flags = fget_flags();
+                unsigned<64> res = fcvt_32_64(unbox_s(F[rs1]), 0, rm);
+                X[rd] = res;
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
+
         FCVT_LU_S { // fp to 64bit unsigned integer
             encoding: 0b1100000 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f{rs1}";
+            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
-                unsigned long res = fcvt_32_64(unbox_s(F[rs1]), 1U, rm);
-                X[rd]= res;
-                unsigned flags = fget_flags();
+                unsigned<64> res = fcvt_32_64(unbox_s(F[rs1]), 1, rm);
+                X[rd] = res;
+                unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
         }
-        FCVT_S_L { // 64bit signed int to to fp 
+
+        FCVT_S_L { // 64bit signed int to to fp
             encoding: 0b1101000 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned res = fcvt_64_32(X[rs1], 2U, rm);
-                if(FLEN==32)
+                unsigned<32> res = fcvt_64_32(X[rs1], 2, rm);
+                if (FLEN == 32)
                     F[rd] = res;
                 else { // NaN boxing
-                        F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                        F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }
-        FCVT_S_LU { // 64bit unsigned int to to fp 
+
+        FCVT_S_LU { // 64bit unsigned int to to fp
             encoding: 0b1101000 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f{rd}, {name(rs1)}";
+            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned res =fcvt_64_32(X[rs1], 3U, rm);
-                if(FLEN==32)
+                unsigned<32> res = fcvt_64_32(X[rs1], 3, rm);
+                if (FLEN == 32)
                     F[rd] = res;
                 else { // NaN boxing
-                        F[rd] = (-1<<32) | (unsigned<FLEN>)res;
+                        F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }
-	}
+    }
 }
-    

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -30,7 +30,7 @@ InstructionSet RV32F extends Zicsr {
     instructions {
         FLW {
             encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0000111;
-            args_disass:"f {rd}, {imm}({name(rs1)})";
+            assembly:"f {rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -44,7 +44,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSW {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: imm[4:0] :: 0b0100111;
-            args_disass:"f {rs2}, {imm}({name(rs1)])";
+            assembly:"f {rs2}, {imm}({name(rs1)])";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 MEM[offs] = (unsigned<32>)F[rs2];
@@ -53,7 +53,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMADD_S {
             encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f + F[rs3]f;
                 if (FLEN == 32)
@@ -69,7 +69,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMSUB_S {
             encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000111;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f - F[rs3]f;
                 if (FLEN == 32)
@@ -85,7 +85,7 @@ InstructionSet RV32F extends Zicsr {
 
         FNMADD_S {
             encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001111;
-            args_disass:"{name(rm)}, name(rd), f {rs1}, f {rs2}, f {rs3}";
+            assembly:"{name(rm)}, name(rd), f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f + F[rs3]f;
                 if (FLEN == 32)
@@ -104,7 +104,7 @@ InstructionSet RV32F extends Zicsr {
 
         FNMSUB_S {
             encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
             //F[rd]f = -F[rs1]f * F[rs2]f - F[rs3]f;
                 if (FLEN == 32)
@@ -123,7 +123,7 @@ InstructionSet RV32F extends Zicsr {
 
         FADD_S {
             encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
                 if (FLEN == 32)
@@ -141,7 +141,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSUB_S {
             encoding: 0b0000100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
                 if (FLEN == 32)
@@ -159,7 +159,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMUL_S {
             encoding: 0b0001000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
                 if (FLEN == 32)
@@ -177,7 +177,7 @@ InstructionSet RV32F extends Zicsr {
 
         FDIV_S {
             encoding: 0b0001100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
                 if (FLEN == 32)
@@ -195,7 +195,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSQRT_S {
             encoding: 0b0101100 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, f {rs1}";
+            assembly:"{name(rm)}, f {rd}, f {rs1}";
             behavior: {
                 //F[rd]f = sqrt(F[rs1]f);
                 if (FLEN == 32)
@@ -212,7 +212,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJ_S {
             encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, f {rs1}, f {rs2}";
+            assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = F[rs2][31:31] :: F[rs1][30:0];
@@ -227,7 +227,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJN_S {
             encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, f {rs1}, f {rs2}";
+            assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = ~F[rs2][31:31] :: F[rs1][30:0];
@@ -242,7 +242,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJX_S {
             encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, f {rs1}, f {rs2}";
+            assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = F[rs1] ^ (F[rs2] & 0x80000000);
@@ -257,7 +257,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMIN_S {
             encoding: 0b0010100 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, f {rs1}, f {rs2}";
+            assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
                 if (FLEN == 32)
@@ -275,7 +275,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMAX_S {
             encoding: 0b0010100 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, f {rs1}, f {rs2}";
+            assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
                 if (FLEN == 32)
@@ -293,7 +293,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_W_S {
             encoding: 0b1100000 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 if (FLEN == 32)
                     X[rd] = fcvt_s(F[rs1], 0, rm);
@@ -308,7 +308,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_WU_S {
             encoding: 0b1100000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //FIXME: according to the spec it should be zero-extended not sign extended
                 if (FLEN == 32)
@@ -324,7 +324,7 @@ InstructionSet RV32F extends Zicsr {
 
         FEQ_S {
             encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
                     X[rd] = fcmp_s(F[rs1], F[rs2], 0);
@@ -340,7 +340,7 @@ InstructionSet RV32F extends Zicsr {
 
         FLT_S {
             encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
                     X[rd] = fcmp_s(F[rs1], F[rs2], 2);
@@ -357,7 +357,7 @@ InstructionSet RV32F extends Zicsr {
 
         FLE_S {
             encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
                     X[rd] = fcmp_s(F[rs1], F[rs2], 1);
@@ -373,7 +373,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCLASS_S {
             encoding: 0b1110000 :: 0b00000 :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f {rs1}";
+            assembly:"{name(rd)}, f {rs1}";
             behavior: {
                 if (FLEN == 32)
                     X[rd] = fclass_s(F[rs1]);
@@ -384,7 +384,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_S_W {
             encoding: 0b1101000 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = fcvt_s((unsigned)X[rs1], 2, rm);
@@ -397,7 +397,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_S_WU {
             encoding: 0b1101000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = fcvt_s((unsigned)X[rs1], 3, rm);
@@ -410,7 +410,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMV_X_W {
             encoding: 0b1110000 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rd)}, f {rs1}";
+            assembly:"{name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = F[rs1];
             }
@@ -418,7 +418,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMV_W_X {
             encoding: 0b1111000 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
-            args_disass:"f {rd}, {name(rs1)}";
+            assembly:"f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = X[rs1];
@@ -434,7 +434,7 @@ InstructionSet RV64F extends RV32F {
     instructions {
         FCVT_L_S { // fp to 64bit signed integer
             encoding: 0b1100000 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 unsigned<64> res = fcvt_32_64(unbox_s(F[rs1]), 0, rm);
                 X[rd] = res;
@@ -445,7 +445,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_LU_S { // fp to 64bit unsigned integer
             encoding: 0b1100000 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 unsigned<64> res = fcvt_32_64(unbox_s(F[rs1]), 1, rm);
                 X[rd] = res;
@@ -456,7 +456,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_S_L { // 64bit signed int to to fp
             encoding: 0b1101000 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<32> res = fcvt_64_32(X[rs1], 2, rm);
                 if (FLEN == 32)
@@ -469,7 +469,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_S_LU { // 64bit unsigned int to to fp
             encoding: 0b1101000 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
-            args_disass:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<32> res = fcvt_64_32(X[rs1], 3, rm);
                 if (FLEN == 32)

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -37,7 +37,7 @@ InstructionSet RV32F extends Zicsr {
                 if (FLEN == 32)
                     F[rd] = res;
                 else { // NaN boxing
-                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
+                    F[rd] = ((signed<FLEN>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -215,12 +215,12 @@ InstructionSet RV32F extends Zicsr {
             args_disass:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
-                    F[rd] = F[rs2][31] :: F[rs1][30:0];
+                    F[rd] = F[rs2][31:31] :: F[rs1][30:0];
                 else { // NaN boxing
                     unsigned<32> frs1 = unbox_s(F[rs1]);
                     unsigned<32> frs2 = unbox_s(F[rs2]);
-                    unsigned<32> res = (frs1 & 0x7fffffff) :: (frs2 & 0x80000000);
-                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
+                    unsigned<32> res = frs2[31:31] :: frs1[30:0];
+                    F[rd] = (-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }
@@ -234,8 +234,8 @@ InstructionSet RV32F extends Zicsr {
                 else { // NaN boxing
                     unsigned<32> frs1 = unbox_s(F[rs1]);
                     unsigned<32> frs2 = unbox_s(F[rs2]);
-                    unsigned<32> res = (frs1 & 0x7fffffff) :: (~frs2 & 0x80000000);
-                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
+                    unsigned<32> res = ~frs2[31:31] :: frs1[30:0];
+                    F[rd] = (-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }
@@ -375,7 +375,10 @@ InstructionSet RV32F extends Zicsr {
             encoding: 0b1110000 :: 0b00000 :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
             args_disass:"{name(rd)}, f {rs1}";
             behavior: {
-                X[rd] = fclass_s(unbox_s(F[rs1]));
+                if (FLEN == 32)
+                    X[rd] = fclass_s(F[rs1]);
+                else
+                    X[rd] = fclass_s(unbox_s(F[rs1]));
             }
         }
 

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -3,7 +3,7 @@ import "RV32I.core_desc"
 // TODO: review instruction description wrt. Spec after type system is fixed
 InstructionSet RV32F extends Zicsr {
     architectural_state {
-        unsigned<32> FLEN;
+        unsigned<32> FLEN = 32;
         unsigned<32> FFLAG_MASK = 0x1f;
 
         register unsigned<FLEN> F[32];

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -33,7 +33,7 @@ InstructionSet RV32F extends Zicsr {
             args_disass:"f {rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
-                unsigned<XLEN> res = MEM[offs];
+                unsigned<32> res = (unsigned<32>)MEM[offs];
                 if (FLEN == 32)
                     F[rd] = res;
                 else { // NaN boxing

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -21,7 +21,7 @@ InstructionSet RV32F extends Zicsr {
         extern unsigned<32> fcmp_s(unsigned<32>, unsigned<32>, unsigned<32>);
         extern unsigned<32> fcvt_s(unsigned<32>, unsigned<32>, unsigned char);
         extern unsigned<64> fcvt_32_64(unsigned<32>, unsigned<32>, unsigned char);
-        extern unsigned<64> fcvt_64_32(unsigned<32>, unsigned<32>, unsigned char);
+        extern unsigned<32> fcvt_64_32(unsigned<64>, unsigned<32>, unsigned char);
         extern unsigned<32> unbox_s(unsigned<64>);
         extern unsigned<32> fclass_s(unsigned<32>);
         extern unsigned<32> fget_flags();

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -29,7 +29,7 @@ InstructionSet RV32F extends Zicsr {
 
     instructions {
         FLW {
-            encoding: imm[11:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0000111;
+            encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0000111;
             assembly:"f {rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
@@ -43,7 +43,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FSW {
-            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 0b010 :: imm[4:0] :: 0b0100111;
+            encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: imm[4:0] :: 7'b0100111;
             assembly:"f {rs2}, {imm}({name(rs1)])";
             behavior: {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
@@ -52,7 +52,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FMADD_S {
-            encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000011;
+            encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f + F[rs3]f;
@@ -68,7 +68,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FMSUB_S {
-            encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1000111;
+            encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000111;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f - F[rs3]f;
@@ -84,7 +84,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FNMADD_S {
-            encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001111;
+            encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001111;
             assembly:"{name(rm)}, name(rd), f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f + F[rs3]f;
@@ -103,7 +103,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FNMSUB_S {
-            encoding: rs3[4:0] :: 0b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1001011;
+            encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
             //F[rd]f = -F[rs1]f * F[rs2]f - F[rs3]f;
@@ -122,7 +122,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FADD_S {
-            encoding: 0b0000000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
@@ -140,7 +140,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FSUB_S {
-            encoding: 0b0000100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0000100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
@@ -158,7 +158,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FMUL_S {
-            encoding: 0b0001000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0001000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
@@ -176,7 +176,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FDIV_S {
-            encoding: 0b0001100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0001100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
@@ -194,7 +194,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FSQRT_S {
-            encoding: 0b0101100 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0101100 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, f {rs1}";
             behavior: {
                 //F[rd]f = sqrt(F[rs1]f);
@@ -211,7 +211,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FSGNJ_S {
-            encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
@@ -226,7 +226,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FSGNJN_S {
-            encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
@@ -241,7 +241,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FSGNJX_S {
-            encoding: 0b0010000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
@@ -256,7 +256,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FMIN_S {
-            encoding: 0b0010100 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0010100 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
@@ -274,7 +274,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FMAX_S {
-            encoding: 0b0010100 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b0010100 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
@@ -292,7 +292,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FCVT_W_S {
-            encoding: 0b1100000 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1100000 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 if (FLEN == 32)
@@ -307,7 +307,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FCVT_WU_S {
-            encoding: 0b1100000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1100000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //FIXME: according to the spec it should be zero-extended not sign extended
@@ -323,7 +323,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FEQ_S {
-            encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
@@ -339,7 +339,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FLT_S {
-            encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
@@ -356,7 +356,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FLE_S {
-            encoding: 0b1010000 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
@@ -372,7 +372,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FCLASS_S {
-            encoding: 0b1110000 :: 0b00000 :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}";
             behavior: {
                 if (FLEN == 32)
@@ -383,7 +383,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FCVT_S_W {
-            encoding: 0b1101000 :: 0b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1101000 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
@@ -396,7 +396,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FCVT_S_WU {
-            encoding: 0b1101000 :: 0b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1101000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
@@ -409,7 +409,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FMV_X_W {
-            encoding: 0b1110000 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}";
             behavior: {
                 X[rd] = F[rs1];
@@ -417,7 +417,7 @@ InstructionSet RV32F extends Zicsr {
         }
 
         FMV_W_X {
-            encoding: 0b1111000 :: 0b00000 :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1111000 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
@@ -433,7 +433,7 @@ InstructionSet RV32F extends Zicsr {
 InstructionSet RV64F extends RV32F {
     instructions {
         FCVT_L_S { // fp to 64bit signed integer
-            encoding: 0b1100000 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1100000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 unsigned<64> res = fcvt_32_64(unbox_s(F[rs1]), 0, rm);
@@ -444,7 +444,7 @@ InstructionSet RV64F extends RV32F {
         }
 
         FCVT_LU_S { // fp to 64bit unsigned integer
-            encoding: 0b1100000 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1100000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 unsigned<64> res = fcvt_32_64(unbox_s(F[rs1]), 1, rm);
@@ -455,7 +455,7 @@ InstructionSet RV64F extends RV32F {
         }
 
         FCVT_S_L { // 64bit signed int to to fp
-            encoding: 0b1101000 :: 0b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1101000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<32> res = fcvt_64_32(X[rs1], 2, rm);
@@ -468,7 +468,7 @@ InstructionSet RV64F extends RV32F {
         }
 
         FCVT_S_LU { // 64bit unsigned int to to fp
-            encoding: 0b1101000 :: 0b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 0b1010011;
+            encoding: 7'b1101000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<32> res = fcvt_64_32(X[rs1], 3, rm);

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -32,7 +32,7 @@ InstructionSet RV32F extends Zicsr {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0000111;
             assembly:"f {rd}, {imm}({name(rs1)})";
             behavior: {
-                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
                 if (FLEN == 32)
                     F[rd] = res;
@@ -46,7 +46,7 @@ InstructionSet RV32F extends Zicsr {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: imm[4:0] :: 7'b0100111;
             assembly:"f {rs2}, {imm}({name(rs1)])";
             behavior: {
-                unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
+                unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 MEM[offs] = (unsigned<32>)F[rs2];
             }
         }
@@ -295,12 +295,14 @@ InstructionSet RV32F extends Zicsr {
             encoding: 7'b1100000 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
+                signed<32> res = 0;
                 if (FLEN == 32)
-                    X[rd] = fcvt_s(F[rs1], 0, rm);
+                    res = fcvt_s(F[rs1], 0, rm);
                 else { // NaN boxing
                     unsigned<32> frs1 = unbox_s(F[rs1]);
-                    X[rd] = fcvt_s(frs1, 0, rm);
+                    res = fcvt_s(frs1, 0, rm);
                 }
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -311,12 +313,14 @@ InstructionSet RV32F extends Zicsr {
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //FIXME: according to the spec it should be zero-extended not sign extended
+                unsigned<32> res = 0;
                 if (FLEN == 32)
-                      X[rd] = fcvt_s(F[rs1], 1, rm);
+                      res = fcvt_s(F[rs1], 1, rm);
                 else { // NaN boxing
                     unsigned<32> frs1 = unbox_s(F[rs1]);
-                    X[rd] = fcvt_s(frs1, 1, rm);
+                    res = fcvt_s(frs1, 1, rm);
                 }
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -326,13 +330,15 @@ InstructionSet RV32F extends Zicsr {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
+                unsigned<32> res = 0;
                 if (FLEN == 32)
-                    X[rd] = fcmp_s(F[rs1], F[rs2], 0);
+                    res = fcmp_s(F[rs1], F[rs2], 0);
                 else {
                     unsigned<32> frs1 = unbox_s(F[rs1]);
                     unsigned<32> frs2 = unbox_s(F[rs2]);
-                    X[rd] = fcmp_s(frs1, frs2, 0);
+                    res = fcmp_s(frs1, frs2, 0);
                 }
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -342,14 +348,15 @@ InstructionSet RV32F extends Zicsr {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
+                unsigned<32> res = 0;
                 if (FLEN == 32)
-                    X[rd] = fcmp_s(F[rs1], F[rs2], 2);
+                    res = fcmp_s(F[rs1], F[rs2], 2);
                 else {
                     unsigned<32> frs1 = unbox_s(F[rs1]);
                     unsigned<32> frs2 = unbox_s(F[rs2]);
-                    X[rd] = fcmp_s(frs1, frs2, 2);
+                    res = fcmp_s(frs1, frs2, 2);
                 }
-                X[rd] = fcmp_s((unsigned)F[rs1], (unsigned)F[rs2], 2);
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -359,13 +366,15 @@ InstructionSet RV32F extends Zicsr {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
+                unsigned<32> res = 0;
                 if (FLEN == 32)
-                    X[rd] = fcmp_s(F[rs1], F[rs2], 1);
+                    res = fcmp_s(F[rs1], F[rs2], 1);
                 else {
                     unsigned<32> frs1 = unbox_s(F[rs1]);
                     unsigned<32> frs2 = unbox_s(F[rs2]);
-                    X[rd] = fcmp_s(frs1, frs2, 1);
+                    res = fcmp_s(frs1, frs2, 1);
                 }
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -375,10 +384,12 @@ InstructionSet RV32F extends Zicsr {
             encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}";
             behavior: {
+                unsigned<32> res = 0;
                 if (FLEN == 32)
-                    X[rd] = fclass_s(F[rs1]);
+                    res = fclass_s(F[rs1]);
                 else
-                    X[rd] = fclass_s(unbox_s(F[rs1]));
+                    res = fclass_s(unbox_s(F[rs1]));
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
             }
         }
 
@@ -387,9 +398,9 @@ InstructionSet RV32F extends Zicsr {
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
-                    F[rd] = fcvt_s((unsigned)X[rs1], 2, rm);
+                    F[rd] = fcvt_s((unsigned)X[rs1 % RFS], 2, rm);
                 else { // NaN boxing
-                    unsigned<32> res = fcvt_s((unsigned)X[rs1], 2, rm);
+                    unsigned<32> res = fcvt_s((unsigned)X[rs1 % RFS], 2, rm);
                     F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
@@ -400,9 +411,9 @@ InstructionSet RV32F extends Zicsr {
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
-                    F[rd] = fcvt_s((unsigned)X[rs1], 3, rm);
+                    F[rd] = fcvt_s((unsigned)X[rs1 % RFS], 3, rm);
                 else { // NaN boxing
-                    unsigned<32> res = fcvt_s((unsigned)X[rs1], 3, rm);
+                    unsigned<32> res = fcvt_s((unsigned)X[rs1 % RFS], 3, rm);
                     F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
@@ -412,7 +423,7 @@ InstructionSet RV32F extends Zicsr {
             encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rd)}, f {rs1}";
             behavior: {
-                X[rd] = F[rs1];
+                if ((rd % RFS) != 0) X[rd % RFS] = F[rs1];
             }
         }
 
@@ -421,9 +432,9 @@ InstructionSet RV32F extends Zicsr {
             assembly:"f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
-                    F[rd] = X[rs1];
+                    F[rd] = X[rs1 % RFS];
                 else { // NaN boxing
-                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)X[rs1];
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)X[rs1 % RFS];
                 }
             }
         }
@@ -436,8 +447,8 @@ InstructionSet RV64F extends RV32F {
             encoding: 7'b1100000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
-                unsigned<64> res = fcvt_32_64(unbox_s(F[rs1]), 0, rm);
-                X[rd] = res;
+                signed<64> res = fcvt_32_64(unbox_s(F[rs1]), 0, rm);
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -448,7 +459,7 @@ InstructionSet RV64F extends RV32F {
             assembly:"{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 unsigned<64> res = fcvt_32_64(unbox_s(F[rs1]), 1, rm);
-                X[rd] = res;
+                if ((rd % RFS) != 0) X[rd % RFS] = res;
                 unsigned<32> flags = fget_flags();
                 FCSR = (FCSR & ~FFLAG_MASK) | (flags & FFLAG_MASK);
             }
@@ -458,11 +469,11 @@ InstructionSet RV64F extends RV32F {
             encoding: 7'b1101000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned<32> res = fcvt_64_32(X[rs1], 2, rm);
+                unsigned<32> res = fcvt_64_32(X[rs1 % RFS], 2, rm);
                 if (FLEN == 32)
                     F[rd] = res;
                 else { // NaN boxing
-                        F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }
@@ -471,11 +482,11 @@ InstructionSet RV64F extends RV32F {
             encoding: 7'b1101000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
             assembly:"{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
-                unsigned<32> res = fcvt_64_32(X[rs1], 3, rm);
+                unsigned<32> res = fcvt_64_32(X[rs1 % RFS], 3, rm);
                 if (FLEN == 32)
                     F[rd] = res;
                 else { // NaN boxing
-                        F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
+                    F[rd] = ((signed<64>)-1 << 32) | (unsigned<FLEN>)res;
                 }
             }
         }

--- a/RVM.core_desc
+++ b/RVM.core_desc
@@ -7,7 +7,7 @@ InstructionSet RV32M extends RISCVBase {
 
     instructions {
         MUL {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -18,7 +18,7 @@ InstructionSet RV32M extends RISCVBase {
         }
 
         MULH {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -29,7 +29,7 @@ InstructionSet RV32M extends RISCVBase {
         }
 
         MULHSU {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -40,7 +40,7 @@ InstructionSet RV32M extends RISCVBase {
         }
 
         MULHU {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -51,7 +51,7 @@ InstructionSet RV32M extends RISCVBase {
         }
 
         DIV {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -68,7 +68,7 @@ InstructionSet RV32M extends RISCVBase {
         }
 
         DIVU {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -81,7 +81,7 @@ InstructionSet RV32M extends RISCVBase {
         }
 
         REM {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -98,7 +98,7 @@ InstructionSet RV32M extends RISCVBase {
         }
 
         REMU {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0110011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -115,7 +115,7 @@ InstructionSet RV32M extends RISCVBase {
 InstructionSet RV64M extends RV32M {
     instructions {
         MULW {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -125,7 +125,7 @@ InstructionSet RV64M extends RV32M {
         }
 
         DIVW {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -142,7 +142,7 @@ InstructionSet RV64M extends RV32M {
         }
 
         DIVUW {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -155,7 +155,7 @@ InstructionSet RV64M extends RV32M {
         }
 
         REMW {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
@@ -172,7 +172,7 @@ InstructionSet RV64M extends RV32M {
         }
 
         REMUW {
-            encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0111011;
+            encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {

--- a/RVM.core_desc
+++ b/RVM.core_desc
@@ -8,7 +8,7 @@ InstructionSet RV32M extends RISCVBase {
     instructions {
         MUL {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
@@ -19,7 +19,7 @@ InstructionSet RV32M extends RISCVBase {
 
         MULH {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
@@ -30,7 +30,7 @@ InstructionSet RV32M extends RISCVBase {
 
         MULHSU {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
@@ -41,7 +41,7 @@ InstructionSet RV32M extends RISCVBase {
 
         MULHU {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     unsigned<MUL_LEN> res = (unsigned<MUL_LEN>)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
@@ -52,7 +52,7 @@ InstructionSet RV32M extends RISCVBase {
 
         DIV {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     if (X[rs2] != 0) {
@@ -69,7 +69,7 @@ InstructionSet RV32M extends RISCVBase {
 
         DIVU {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     if (X[rs2] != 0)
@@ -82,7 +82,7 @@ InstructionSet RV32M extends RISCVBase {
 
         REM {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     if (X[rs2] != 0) {
@@ -99,7 +99,7 @@ InstructionSet RV32M extends RISCVBase {
 
         REMU {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0110011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     if (X[rs2] != 0)
@@ -116,7 +116,7 @@ InstructionSet RV64M extends RV32M {
     instructions {
         MULW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     X[rd] = (signed<MUL_LEN>)(signed<32>)X[rs1] * (signed<MUL_LEN>)(signed<32>)X[rs2];
@@ -126,7 +126,7 @@ InstructionSet RV64M extends RV32M {
 
         DIVW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     if (X[rs2] != 0) {
@@ -143,7 +143,7 @@ InstructionSet RV64M extends RV32M {
 
         DIVUW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     if ((unsigned<32>)X[rs2] != 0)
@@ -156,7 +156,7 @@ InstructionSet RV64M extends RV32M {
 
         REMW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     if (X[rs2] != 0) {
@@ -173,7 +173,7 @@ InstructionSet RV64M extends RV32M {
 
         REMUW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0111011;
-            args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
                 if (rd != 0) {
                     if ((unsigned<32>)X[rs2] != 0)

--- a/RVM.core_desc
+++ b/RVM.core_desc
@@ -10,9 +10,9 @@ InstructionSet RV32M extends RISCVBase {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
-                    X[rd] = (unsigned<XLEN>)res;
+                if ((rd % RFS) != 0) {
+                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1 % RFS] * (signed<MUL_LEN>)(signed)X[rs2 % RFS];
+                    X[rd % RFS] = (unsigned<XLEN>)res;
                 }
             }
         }
@@ -21,9 +21,9 @@ InstructionSet RV32M extends RISCVBase {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
-                    X[rd] = (unsigned<XLEN>)(res >> XLEN);
+                if ((rd % RFS) != 0) {
+                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1 % RFS] * (signed<MUL_LEN>)(signed)X[rs2 % RFS];
+                    X[rd % RFS] = (unsigned<XLEN>)(res >> XLEN);
                 }
             }
         }
@@ -32,9 +32,9 @@ InstructionSet RV32M extends RISCVBase {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
-                        X[rd] = (unsigned<XLEN>)(res >> XLEN);
+                if ((rd % RFS) != 0) {
+                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1 % RFS] * (unsigned<MUL_LEN>)X[rs2 % RFS];
+                        X[rd % RFS] = (unsigned<XLEN>)(res >> XLEN);
                 }
             }
         }
@@ -43,9 +43,9 @@ InstructionSet RV32M extends RISCVBase {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    unsigned<MUL_LEN> res = (unsigned<MUL_LEN>)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
-                    X[rd] = (unsigned<XLEN>)(res >> XLEN);
+                if ((rd % RFS) != 0) {
+                    unsigned<MUL_LEN> res = (unsigned<MUL_LEN>)X[rs1 % RFS] * (unsigned<MUL_LEN>)X[rs2 % RFS];
+                    X[rd % RFS] = (unsigned<XLEN>)(res >> XLEN);
                 }
             }
         }
@@ -54,15 +54,15 @@ InstructionSet RV32M extends RISCVBase {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    if (X[rs2] != 0) {
+                if ((rd % RFS) != 0) {
+                    if (X[rs2 % RFS] != 0) {
                         unsigned<XLEN> MMIN = 1<<(XLEN-1);
-                        if (X[rs1] == MMIN && (signed<XLEN>)X[rs2] == -1)
-                            X[rd] = MMIN;
+                        if (X[rs1 % RFS] == MMIN && (signed<XLEN>)X[rs2 % RFS] == -1)
+                            X[rd % RFS] = MMIN;
                         else
-                            X[rd] = (signed<XLEN>)X[rs1] / (signed<XLEN>)X[rs2];
+                            X[rd % RFS] = (signed<XLEN>)X[rs1 % RFS] / (signed<XLEN>)X[rs2 % RFS];
                     }else
-                        X[rd] = -1;
+                        X[rd % RFS] = -1;
                 }
             }
         }
@@ -71,11 +71,11 @@ InstructionSet RV32M extends RISCVBase {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    if (X[rs2] != 0)
-                        X[rd] = X[rs1] / X[rs2];
+                if ((rd % RFS) != 0) {
+                    if (X[rs2 % RFS] != 0)
+                        X[rd % RFS] = X[rs1 % RFS] / X[rs2 % RFS];
                     else
-                        X[rd] = -1;
+                        X[rd % RFS] = -1;
                 }
             }
         }
@@ -84,15 +84,15 @@ InstructionSet RV32M extends RISCVBase {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    if (X[rs2] != 0) {
+                if ((rd % RFS) != 0) {
+                    if (X[rs2 % RFS] != 0) {
                         unsigned<XLEN> MMIN = 1<<(XLEN-1);
-                        if (X[rs1] == MMIN && (signed<XLEN>)X[rs2] == -1)
-                            X[rd] = 0;
+                        if (X[rs1 % RFS] == MMIN && (signed<XLEN>)X[rs2 % RFS] == -1)
+                            X[rd % RFS] = 0;
                         else
-                            X[rd] = (signed<XLEN>)X[rs1] % (signed<XLEN>)X[rs2];
+                            X[rd % RFS] = (signed<XLEN>)X[rs1 % RFS] % (signed<XLEN>)X[rs2 % RFS];
                     } else
-                        X[rd] = X[rs1];
+                        X[rd % RFS] = X[rs1 % RFS];
                 }
             }
         }
@@ -101,11 +101,11 @@ InstructionSet RV32M extends RISCVBase {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0110011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    if (X[rs2] != 0)
-                        X[rd] = X[rs1] % X[rs2];
+                if ((rd % RFS) != 0) {
+                    if (X[rs2 % RFS] != 0)
+                        X[rd % RFS] = X[rs1 % RFS] % X[rs2 % RFS];
                     else
-                        X[rd] = X[rs1];
+                        X[rd % RFS] = X[rs1 % RFS];
                 }
             }
         }
@@ -118,8 +118,8 @@ InstructionSet RV64M extends RV32M {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    X[rd] = (signed<MUL_LEN>)(signed<32>)X[rs1] * (signed<MUL_LEN>)(signed<32>)X[rs2];
+                if ((rd % RFS) != 0) {
+                    X[rd % RFS] = (signed<MUL_LEN>)(signed<32>)X[rs1 % RFS] * (signed<MUL_LEN>)(signed<32>)X[rs2 % RFS];
                 }
             }
         }
@@ -128,15 +128,15 @@ InstructionSet RV64M extends RV32M {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    if (X[rs2] != 0) {
+                if ((rd % RFS) != 0) {
+                    if (X[rs2 % RFS] != 0) {
                         signed<32> MMIN = 1<<31;
-                        if ((signed<32>)X[rs1] == MMIN && (signed<32>)X[rs2] == -1)
-                            X[rd] = -1<<31;
+                        if ((signed<32>)X[rs1 % RFS] == MMIN && (signed<32>)X[rs2 % RFS] == -1)
+                            X[rd % RFS] = -1<<31;
                         else
-                            X[rd] = (signed<XLEN>)((signed<32>)X[rs1] / (signed<32>)X[rs2]);
+                            X[rd % RFS] = (signed<XLEN>)((signed<32>)X[rs1 % RFS] / (signed<32>)X[rs2 % RFS]);
                     }else
-                        X[rd] = -1;
+                        X[rd % RFS] = -1;
                 }
             }
         }
@@ -145,11 +145,11 @@ InstructionSet RV64M extends RV32M {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    if ((unsigned<32>)X[rs2] != 0)
-                        X[rd] = (signed<XLEN>)((unsigned<32>)X[rs1] / (unsigned<32>)X[rs2]);
+                if ((rd % RFS) != 0) {
+                    if ((unsigned<32>)X[rs2 % RFS] != 0)
+                        X[rd % RFS] = (signed<XLEN>)((unsigned<32>)X[rs1 % RFS] / (unsigned<32>)X[rs2 % RFS]);
                     else
-                        X[rd] = -1;
+                        X[rd % RFS] = -1;
                 }
             }
         }
@@ -158,15 +158,15 @@ InstructionSet RV64M extends RV32M {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    if (X[rs2] != 0) {
+                if ((rd % RFS) != 0) {
+                    if (X[rs2 % RFS] != 0) {
                         signed<32> MMIN = 1<<31;
-                        if ((signed<32>)X[rs1] == MMIN && (signed<32>)X[rs2] == -1)
-                            X[rd] = 0;
+                        if ((signed<32>)X[rs1 % RFS] == MMIN && (signed<32>)X[rs2 % RFS] == -1)
+                            X[rd % RFS] = 0;
                         else
-                            X[rd] = (signed<XLEN>)((signed<32>)X[rs1] % (signed<32>)X[rs2]);
+                            X[rd % RFS] = (signed<XLEN>)((signed<32>)X[rs1 % RFS] % (signed<32>)X[rs2 % RFS]);
                     } else
-                        X[rd] = (signed<XLEN>)((signed<32>)X[rs1]);
+                        X[rd % RFS] = (signed<XLEN>)((signed<32>)X[rs1 % RFS]);
                 }
             }
         }
@@ -175,11 +175,11 @@ InstructionSet RV64M extends RV32M {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0111011;
             assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-                if (rd != 0) {
-                    if ((unsigned<32>)X[rs2] != 0)
-                        X[rd] = (signed<XLEN>)((unsigned<32>)X[rs1] % (unsigned<32>)X[rs2]);
+                if ((rd % RFS) != 0) {
+                    if ((unsigned<32>)X[rs2 % RFS] != 0)
+                        X[rd % RFS] = (signed<XLEN>)((unsigned<32>)X[rs1 % RFS] % (unsigned<32>)X[rs2 % RFS]);
                     else
-                        X[rd] = (signed<XLEN>)((signed<32>)X[rs1]);
+                        X[rd % RFS] = (signed<XLEN>)((signed<32>)X[rs1 % RFS]);
                 }
             }
         }

--- a/RVM.core_desc
+++ b/RVM.core_desc
@@ -2,175 +2,186 @@ import "RISCVBase.core_desc"
 
 InstructionSet RV32M extends RISCVBase {
     architectural_state {
-        unsigned MUL_LEN=2*XLEN;
+        unsigned<32> MUL_LEN = 2 * XLEN;
     }
-    instructions{       
-        MUL{
+
+    instructions {
+        MUL {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
-	                X[rd]= (unsigned<XLEN>)res;
-	            }
+                if (rd != 0) {
+                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
+                    X[rd] = (unsigned<XLEN>)res;
+                }
             }
         }
+
         MULH {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b001 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
-	                X[rd]= (unsigned<XLEN>)(res >> XLEN);
-	            }
+                if (rd != 0) {
+                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
+                    X[rd] = (unsigned<XLEN>)(res >> XLEN);
+                }
             }
         }
+
         MULHSU {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b010 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	            	signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
-		                X[rd]= (unsigned<XLEN>)(res >> XLEN);
-	            }
+                if (rd != 0) {
+                    signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
+                        X[rd] = (unsigned<XLEN>)(res >> XLEN);
+                }
             }
         }
+
         MULHU {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b011 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                unsigned<MUL_LEN> res = (unsigned<MUL_LEN>)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
-	                X[rd]= (unsigned<XLEN>)(res >> XLEN);
-	            }
+                if (rd != 0) {
+                    unsigned<MUL_LEN> res = (unsigned<MUL_LEN>)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
+                    X[rd] = (unsigned<XLEN>)(res >> XLEN);
+                }
             }
         }
+
         DIV {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                if(X[rs2]!=0){
-	                    unsigned<XLEN> MMIN = 1<<(XLEN-1);
-	                    if(X[rs1]==MMIN && (signed<XLEN>)X[rs2]==-1)
-	                        X[rd] = MMIN;
-	                    else
-	                        X[rd] = (signed<XLEN>)X[rs1] / (signed<XLEN>)X[rs2];
-	                }else 
-	                    X[rd] = -1;
-	            }
+                if (rd != 0) {
+                    if (X[rs2] != 0) {
+                        unsigned<XLEN> MMIN = 1<<(XLEN-1);
+                        if (X[rs1] == MMIN && (signed<XLEN>)X[rs2] == -1)
+                            X[rd] = MMIN;
+                        else
+                            X[rd] = (signed<XLEN>)X[rs1] / (signed<XLEN>)X[rs2];
+                    }else
+                        X[rd] = -1;
+                }
             }
         }
+
         DIVU {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-            if(rd != 0){
-                if(X[rs2]!=0)
-                    X[rd] = X[rs1] / X[rs2];
-                else 
-                    X[rd] = -1;
-            }
+                if (rd != 0) {
+                    if (X[rs2] != 0)
+                        X[rd] = X[rs1] / X[rs2];
+                    else
+                        X[rd] = -1;
+                }
             }
         }
+
         REM {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                if(X[rs2]!=0) {
-	                    unsigned<XLEN> MMIN = 1<<(XLEN-1);
-	                    if(X[rs1]==MMIN && (signed<XLEN>)X[rs2]==-1)
-	                        X[rd] = 0;
-	                    else
-	                        X[rd] = (signed<XLEN>)X[rs1] % (signed<XLEN>)X[rs2];
-	                } else 
-	                    X[rd] = X[rs1];
-	            }
+                if (rd != 0) {
+                    if (X[rs2] != 0) {
+                        unsigned<XLEN> MMIN = 1<<(XLEN-1);
+                        if (X[rs1] == MMIN && (signed<XLEN>)X[rs2] == -1)
+                            X[rd] = 0;
+                        else
+                            X[rd] = (signed<XLEN>)X[rs1] % (signed<XLEN>)X[rs2];
+                    } else
+                        X[rd] = X[rs1];
+                }
             }
         }
+
         REMU {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0110011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-            if(rd != 0){
-                if(X[rs2]!=0)
-                    X[rd] = X[rs1] % X[rs2];
-                else 
-                    X[rd] = X[rs1];
-            }
+                if (rd != 0) {
+                    if (X[rs2] != 0)
+                        X[rd] = X[rs1] % X[rs2];
+                    else
+                        X[rd] = X[rs1];
+                }
             }
         }
     }
 }
 
 InstructionSet RV64M extends RV32M {
-    instructions{       
-        MULW{
+    instructions {
+        MULW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b000 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                X[rd]= (signed<MUL_LEN>)(signed<32>)X[rs1] * (signed<MUL_LEN>)(signed<32>)X[rs2];
-	            }
+                if (rd != 0) {
+                    X[rd] = (signed<MUL_LEN>)(signed<32>)X[rs1] * (signed<MUL_LEN>)(signed<32>)X[rs2];
+                }
             }
         }
+
         DIVW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b100 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                if(X[rs2]!=0){
-	                    signed<32> MMIN = 1<<31;
-	                    if((signed<32>)X[rs1]==MMIN && (signed<32>)X[rs2]==-1)
-	                        X[rd] = -1<<31;
-	                    else
-	                        X[rd] = (signed<XLEN>)((signed<32>)X[rs1] / (signed<32>)X[rs2]);
-	                }else 
-	                    X[rd] = -1;
-	            }
+                if (rd != 0) {
+                    if (X[rs2] != 0) {
+                        signed<32> MMIN = 1<<31;
+                        if ((signed<32>)X[rs1] == MMIN && (signed<32>)X[rs2] == -1)
+                            X[rd] = -1<<31;
+                        else
+                            X[rd] = (signed<XLEN>)((signed<32>)X[rs1] / (signed<32>)X[rs2]);
+                    }else
+                        X[rd] = -1;
+                }
             }
         }
+
         DIVUW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b101 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-		            if((unsigned<32>)X[rs2]!=0)
-		                X[rd] = (signed<XLEN>)((unsigned<32>)X[rs1] / (unsigned<32>)X[rs2]);
-		            else 
-		                X[rd] = -1;
-		        }
-	        }
+                if (rd != 0) {
+                    if ((unsigned<32>)X[rs2] != 0)
+                        X[rd] = (signed<XLEN>)((unsigned<32>)X[rs1] / (unsigned<32>)X[rs2]);
+                    else
+                        X[rd] = -1;
+                }
+            }
         }
+
         REMW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b110 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-	                if(X[rs2]!=0) {
-	                    signed<32> MMIN = 1<<31;
-	                    if((signed<32>)X[rs1]==MMIN && (signed<32>)X[rs2]==-1)
-	                        X[rd] = 0;
-	                    else
-	                        X[rd] = (signed<XLEN>)((signed<32>)X[rs1] % (signed<32>)X[rs2]);
-	                } else 
-	                    X[rd] = (signed<XLEN>)((signed<32>)X[rs1]);
-	            }
+                if (rd != 0) {
+                    if (X[rs2] != 0) {
+                        signed<32> MMIN = 1<<31;
+                        if ((signed<32>)X[rs1] == MMIN && (signed<32>)X[rs2] == -1)
+                            X[rd] = 0;
+                        else
+                            X[rd] = (signed<XLEN>)((signed<32>)X[rs1] % (signed<32>)X[rs2]);
+                    } else
+                        X[rd] = (signed<XLEN>)((signed<32>)X[rs1]);
+                }
             }
         }
+
         REMUW {
             encoding: 0b0000001 :: rs2[4:0] :: rs1[4:0] :: 0b111 :: rd[4:0] :: 0b0111011;
             args_disass:"{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: {
-	            if(rd != 0){
-		            if((unsigned<32>)X[rs2]!=0)
-		                X[rd] = (signed<XLEN>)((unsigned<32>)X[rs1] % (unsigned<32>)X[rs2]);
-		            else 
-	                    X[rd] = (signed<XLEN>)((signed<32>)X[rs1]);
-        	    }
+                if (rd != 0) {
+                    if ((unsigned<32>)X[rs2] != 0)
+                        X[rd] = (signed<XLEN>)((unsigned<32>)X[rs1] % (unsigned<32>)X[rs2]);
+                    else
+                        X[rd] = (signed<XLEN>)((signed<32>)X[rs1]);
+                }
             }
         }
     }
 }
-


### PR DESCRIPTION
These changes have been made while integrating the CoreDSL 2 generated RISC-V models in [ETISS](https://github.com/tum-ei-eda/etiss). Currently a `RV32GC + Zicsr + Zifencei` core passes all relevant tests of the [RISC-V instruction test suite](https://github.com/riscv-software-src/riscv-tests), except the instructions `LR` and `SC`; the ETISS model provides own implementations for these [here](https://github.com/tum-ei-eda/etiss_arch_riscv/blob/master/tum_mod.core_desc#L137-L165). If interested, I would include them here.

Changes include but not limited to:

- Many typing fixes
- Formatting fixes
- Memory access width fixes, mostly making sure that instructions will work for any `XLEN`
- Changes to inheritance hierarchy to reflect the RISC-V reference manual
- Set defaults for `XLEN`, `FLEN`, `MUL_LEN` in the ISA extensions
- Various functionality fixes to make tests pass