### PR TITLE
Update assembly lines (Mnemonics)

### DIFF
--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -47,7 +47,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BEQ [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
-            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if(rs2 >=RFS || rs1 >= RFS) raise(0, 2); else  {
                 if (X[rs1] == X[rs2]) {
                     if(imm % INSTR_ALIGNMENT) {
@@ -61,7 +61,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BNE [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
-            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if(rs2 >=RFS || rs1 >= RFS) raise(0, 2); else {
                 if (X[rs1] != X[rs2]) {
                     if (imm % INSTR_ALIGNMENT) {
@@ -75,7 +75,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BLT [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
-            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if(rs2 >=RFS || rs1 >= RFS) raise(0, 2); else {
                 if ((signed<XLEN>)X[rs1] < (signed<XLEN>)X[rs2]) {
                     if (imm % INSTR_ALIGNMENT) {
@@ -89,7 +89,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BGE [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
-            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if(rs2 >=RFS || rs1 >= RFS) raise(0, 2); else {
                 if ((signed<XLEN>)X[rs1] >= (signed<XLEN>)X[rs2]) {
                     if (imm % INSTR_ALIGNMENT) {
@@ -103,7 +103,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BLTU [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
-            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if(rs2 >=RFS || rs1 >= RFS) raise(0, 2); else {
                 if (X[rs1] < X[rs2]) {
                     if (imm % INSTR_ALIGNMENT) {
@@ -117,7 +117,7 @@ InstructionSet RV32I extends RISCVBase {
 
         BGEU [[no_cont]] [[cond]] {
             encoding: imm[12:12] ::imm[10:5] :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: imm[4:1] :: imm[11:11] :: 7'b1100011;
-            assembly:"{name(rs1)}, {name(rs2)}, {imm:#0x}";
+            assembly: "{name(rs1)}, {name(rs2)}, {imm:#0x}";
             behavior: if(rs2 >=RFS || rs1 >= RFS) raise(0, 2); else {
                 if (X[rs1] >= X[rs2]) {
                     if (imm % INSTR_ALIGNMENT) {
@@ -131,7 +131,7 @@ InstructionSet RV32I extends RISCVBase {
 
         LB {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0000011;
-            assembly:"{name(rd)}, {imm}({name(rs1)})";
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<8> res = (signed<8>)MEM[load_address];
@@ -141,7 +141,7 @@ InstructionSet RV32I extends RISCVBase {
 
         LH {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0000011;
-            assembly:"{name(rd)}, {imm}({name(rs1)})";
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<16> res = (signed<16>)MEM[load_address];
@@ -151,7 +151,7 @@ InstructionSet RV32I extends RISCVBase {
 
         LW {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0000011;
-            assembly:"{name(rd)}, {imm}({name(rs1)})";
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 signed<32> res = (signed<32>)MEM[load_address];
@@ -161,7 +161,7 @@ InstructionSet RV32I extends RISCVBase {
 
         LBU {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0000011;
-            assembly:"{name(rd)}, {imm}({name(rs1)})";
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 unsigned<8> res = (unsigned<8>)MEM[load_address];
@@ -171,7 +171,7 @@ InstructionSet RV32I extends RISCVBase {
 
         LHU {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0000011;
-            assembly:"{name(rd)}, {imm}({name(rs1)})";
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> load_address = X[rs1] + (signed<12>)imm;
                 unsigned<16> res = (unsigned<16>)MEM[load_address];
@@ -181,7 +181,7 @@ InstructionSet RV32I extends RISCVBase {
 
         SB {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: imm[4:0] :: 7'b0100011;
-            assembly:"{name(rs2)}, {imm}({name(rs1)})";
+            assembly: "{name(rs2)}, {imm}({name(rs1)})";
             behavior: if(rs2 >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> store_address = X[rs1] + (signed)imm;
                 MEM[store_address] = (signed<8>)X[rs2];
@@ -190,7 +190,7 @@ InstructionSet RV32I extends RISCVBase {
 
         SH {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: imm[4:0] :: 7'b0100011;
-            assembly:"{name(rs2)}, {imm}({name(rs1)})";
+            assembly: "{name(rs2)}, {imm}({name(rs1)})";
             behavior: if(rs2 >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> store_address = X[rs1] + (signed)imm;
                 MEM[store_address] = (signed<16>)X[rs2];
@@ -199,7 +199,7 @@ InstructionSet RV32I extends RISCVBase {
 
         SW {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: imm[4:0] :: 7'b0100011;
-            assembly:"{name(rs2)}, {imm}({name(rs1)})";
+            assembly: "{name(rs2)}, {imm}({name(rs1)})";
             behavior: if(rs2 >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> store_address = X[rs1] + (signed)imm;
                 MEM[store_address] = (signed<32>)X[rs2];
@@ -208,121 +208,121 @@ InstructionSet RV32I extends RISCVBase {
 
         ADDI {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] + (signed)imm;
         }
 
         SLTI {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = ((signed)X[rs1] < (signed)imm) ? 1 : 0;
         }
 
         SLTIU {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = (X[rs1] < (unsigned<XLEN>)((signed)imm)) ? 1 : 0;
         }
 
         XORI {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] ^ (unsigned<XLEN>)((signed)imm);
         }
 
         ORI {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] | (unsigned<XLEN>)((signed)imm);
         }
 
         ANDI {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] & (unsigned<XLEN>)((signed)imm);
         }
 
         SLLI {
             encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] << shamt;
         }
 
         SRLI {
             encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] >> shamt;
         }
 
         SRAI {
             encoding: 7'b0100000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = (signed)X[rs1] >> shamt;
         }
 
         ADD {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] + X[rs2];
         }
 
         SUB {
             encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] - X[rs2];
         }
 
         SLL {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] << (X[rs2] & (XLEN - 1));
         }
 
         SLT {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = (signed)X[rs1] < (signed)X[rs2] ? 1 : 0;
         }
 
         SLTU {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
                behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] < X[rs2] ? 1 : 0;
         }
 
         XOR {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] ^ X[rs2];
         }
 
         SRL {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] >> (X[rs2] & (XLEN - 1));
         }
 
         SRA {
             encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = (signed)X[rs1] >> (X[rs2] & (XLEN - 1));
         }
 
         OR {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] | X[rs2];
         }
 
         AND {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] & X[rs2];
         }
 
         FENCE {
             encoding: fm[3:0] :: pred[3:0] :: succ[3:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0001111;
-            assembly:"{pred}, {succ} ({fm} , {name(rs1)}, {name(rd)})";
+            assembly: "{pred}, {succ} ({fm} , {name(rs1)}, {name(rd)})";
             behavior: FENCE[fence] = pred << 4 | succ;
         }
 
@@ -356,7 +356,7 @@ InstructionSet Zicsr extends RISCVBase {
     instructions {
         CSRRW {
             encoding: csr[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1110011;
-            assembly:"{name(rd)}, {csr}, {name(rs1)}";
+            assembly: "{name(rd)}, {csr}, {name(rs1)}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> xrs1 = X[rs1];
                 if (rd != 0) {
@@ -372,7 +372,7 @@ InstructionSet Zicsr extends RISCVBase {
 
         CSRRS {
             encoding: csr[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1110011;
-            assembly:"{name(rd)}, {csr}, {name(rs1)}";
+            assembly: "{name(rd)}, {csr}, {name(rs1)}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> xrd = CSR[csr];
                 unsigned<XLEN> xrs1 = X[rs1];
@@ -383,7 +383,7 @@ InstructionSet Zicsr extends RISCVBase {
 
         CSRRC {
             encoding: csr[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b1110011;
-            assembly:"{name(rd)}, {csr}, {name(rs1)}";
+            assembly: "{name(rd)}, {csr}, {name(rs1)}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> xrd = CSR[csr];
                 unsigned<XLEN> xrs1 = X[rs1];
@@ -394,7 +394,7 @@ InstructionSet Zicsr extends RISCVBase {
 
         CSRRWI {
             encoding: csr[11:0] :: zimm[4:0] :: 3'b101 :: rd[4:0] :: 7'b1110011;
-            assembly:"{name(rd)}, {csr}, {zimm:#0x}";
+            assembly: "{name(rd)}, {csr}, {zimm:#0x}";
             behavior: if(rd >=RFS) raise(0, 2); else {
                 unsigned<XLEN> xrd = CSR[csr];
                 CSR[csr] = (unsigned<XLEN>)zimm;
@@ -404,7 +404,7 @@ InstructionSet Zicsr extends RISCVBase {
 
         CSRRSI {
             encoding: csr[11:0] :: zimm[4:0] :: 3'b110 :: rd[4:0] :: 7'b1110011;
-            assembly:"{name(rd)}, {csr}, {zimm:#0x}";
+            assembly: "{name(rd)}, {csr}, {zimm:#0x}";
             behavior: if(rd >=RFS) raise(0, 2); else {
                 unsigned<XLEN> xrd = CSR[csr];
                 if (zimm != 0) CSR[csr] = xrd | (unsigned<XLEN>)zimm;
@@ -414,7 +414,7 @@ InstructionSet Zicsr extends RISCVBase {
 
         CSRRCI {
             encoding: csr[11:0] :: zimm[4:0] :: 3'b111 :: rd[4:0] :: 7'b1110011;
-            assembly:"{name(rd)}, {csr}, {zimm:#0x}";
+            assembly: "{name(rd)}, {csr}, {zimm:#0x}";
             behavior: if(rd >=RFS) raise(0, 2); else {
                 unsigned<XLEN> xrd = CSR[csr];
                 if (zimm != 0) CSR[csr] = xrd & ~((unsigned<XLEN>)zimm);
@@ -428,7 +428,7 @@ InstructionSet Zifencei extends RISCVBase {
     instructions {
         FENCE_I [[flush]] {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0001111 ;
-            assembly:"{name(rs1)}, {name(rd)}, {imm}";
+            assembly: "{name(rs1)}, {name(rd)}, {imm}";
             behavior: FENCE[fencei] = imm;
         }
     }

--- a/RV32I.core_desc
+++ b/RV32I.core_desc
@@ -428,7 +428,7 @@ InstructionSet Zifencei extends RISCVBase {
     instructions {
         FENCE_I [[flush]] {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0001111 ;
-            assembly: "{name(rs1)}, {name(rd)}, {imm}";
+            assembly: {"fence.i", "{name(rs1)}, {name(rd)}, {imm}"};
             behavior: FENCE[fencei] = imm;
         }
     }
@@ -461,7 +461,7 @@ InstructionSet RVDebug extends RISCVBase {
                     raise(0, 2);
                 else {
                     PC=DPC;
-                    PRIV &= 0x3;                    
+                    PRIV &= 0x3;
                 }
             }
         }

--- a/RV64I.core_desc
+++ b/RV64I.core_desc
@@ -8,7 +8,7 @@ InstructionSet RV64I extends RV32I {
     instructions {
         LWU { // 80000104: 0000ef03 lwu t5,0(ra)
             encoding: imm[11:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0000011;
-            assembly:"{name(rd)}, {imm}({name(rs1)})";
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -18,7 +18,7 @@ InstructionSet RV64I extends RV32I {
 
         LD {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0000011;
-            assembly:"{name(rd)}, {imm}({name(rs1)})";
+            assembly: "{name(rd)}, {imm}({name(rs1)})";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 signed<64> res = (signed<64>)MEM[offs];
@@ -28,7 +28,7 @@ InstructionSet RV64I extends RV32I {
 
         SD {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: imm[4:0] :: 7'b0100011;
-            assembly:"{name(rs2)}, {imm}({name(rs1)})";
+            assembly: "{name(rs2)}, {imm}({name(rs1)})";
             behavior: if(rs2 >=RFS || rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> offs = X[rs1] + (signed<12>)imm;
                 MEM[offs] = (unsigned<XLEN>)X[rs2];
@@ -37,13 +37,13 @@ InstructionSet RV64I extends RV32I {
 
         SLLI {
             encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs1] << shamt;
         }
 
         SRLI {
             encoding: 0b000000 :: shamt[5:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else
                 if (rd != 0)
                     X[rd] = X[rs1] >> shamt;
@@ -51,7 +51,7 @@ InstructionSet RV64I extends RV32I {
 
         SRAI {
             encoding: 0b010000 :: shamt[5:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0010011;
-            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else
                 if (rd != 0)
                     X[rd] = ((signed<XLEN>)X[rs1]) >> shamt;
@@ -59,7 +59,7 @@ InstructionSet RV64I extends RV32I {
 
         ADDIW {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0011011;
-            assembly:"{name(rd)}, {name(rs1)}, {imm}";
+            assembly: "{name(rd)}, {name(rs1)}, {imm}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 if (rd != 0) {
                     signed<32> res = X[rs1] + (signed<12>)imm;
@@ -70,7 +70,7 @@ InstructionSet RV64I extends RV32I {
 
         SLLIW {
             encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0011011;
-            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 if (rd != 0) {
                     unsigned<32> sh_val = ((unsigned<32>)X[rs1]) <<  shamt;
@@ -81,7 +81,7 @@ InstructionSet RV64I extends RV32I {
 
         SRLIW {
             encoding: 7'b0000000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0011011;
-            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 if (rd != 0) {
                     unsigned<32> sh_val = ((unsigned<32>)X[rs1]) >> shamt;
@@ -92,7 +92,7 @@ InstructionSet RV64I extends RV32I {
 
         SRAIW {
             encoding: 7'b0100000 :: shamt[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0011011;
-            assembly:"{name(rd)}, {name(rs1)}, {shamt}";
+            assembly: "{name(rd)}, {name(rs1)}, {shamt}";
             behavior: if(rd >=RFS || rs1 >= RFS) raise(0, 2); else {
                 if (rd != 0) {
                     signed<32> sh_val = ((signed<32>)X[rs1]) >> shamt;
@@ -123,7 +123,7 @@ InstructionSet RV64I extends RV32I {
 
         SLLW {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0111011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else {
                 if (rd != 0) {
                     unsigned<32> count = (unsigned)X[rs2] & 0x1f;
@@ -135,7 +135,7 @@ InstructionSet RV64I extends RV32I {
 
         SRLW {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else {
                 if (rd != 0) {
                     unsigned<32> count = (unsigned)X[rs2] & 0x1f;
@@ -147,7 +147,7 @@ InstructionSet RV64I extends RV32I {
 
         SRAW {
             encoding: 7'b0100000 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1 >= RFS || rs2 >= RFS) raise(0, 2); else {
                 if (rd != 0) {
                     unsigned<32> count = (unsigned)X[rs2] & 0x1f;

--- a/RVA.core_desc
+++ b/RVA.core_desc
@@ -27,7 +27,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOSWAPW {
             encoding: 5'b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amoswap.w", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 if ((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)((signed<32>)MEM[offs]);
@@ -37,7 +37,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOADDW {
             encoding: 5'b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amoadd.w", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
@@ -49,7 +49,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOXORW {
             encoding: 5'b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amoxor.w", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
@@ -61,7 +61,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOANDW {
             encoding: 5'b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amoand.w", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
@@ -73,7 +73,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOORW {
             encoding: 5'b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amoor.w", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
@@ -85,7 +85,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOMINW {
             encoding: 5'b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amomin.w", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
@@ -97,7 +97,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOMAXW {
             encoding: 5'b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amomax.w", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<32> res1 = MEM[offs];
@@ -109,7 +109,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOMINUW {
             encoding: 5'b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amominu.w", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 unsigned<32> res1 = MEM[offs];
@@ -121,7 +121,7 @@ InstructionSet RV32A extends RISCVBase {
 
         AMOMAXUW {
             encoding: 5'b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amomaxu.w", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 unsigned<32> res1 = MEM[offs];
@@ -162,7 +162,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOSWAPD {
             encoding: 5'b00001 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amoswap.d", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 if ((rd % RFS) != 0) X[rd % RFS] = (signed<XLEN>)((signed<64>)MEM[offs]);
@@ -172,7 +172,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOADDD {
             encoding: 5'b00000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amoadd.d", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<64> res = MEM[offs];
@@ -184,7 +184,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOXORD {
             encoding: 5'b00100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amoxor.d", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<64> res = MEM[offs];
@@ -196,7 +196,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOANDD {
             encoding: 5'b01100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amoand.d", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<64> res = MEM[offs];
@@ -208,7 +208,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOORD {
             encoding: 5'b01000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amoor.d", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<64> res = MEM[offs];
@@ -220,7 +220,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOMIND {
             encoding: 5'b10000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amomin.d", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<64> res1 = MEM[offs];
@@ -232,7 +232,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOMAXD {
             encoding: 5'b10100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amomax.d", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 signed<64> res = MEM[offs];
@@ -244,7 +244,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOMINUD {
             encoding: 5'b11000 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amominu.d", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 unsigned<64> res = MEM[offs];
@@ -256,7 +256,7 @@ InstructionSet RV64A extends RV32A {
 
         AMOMAXUD {
             encoding: 5'b11100 :: aq[0:0] :: rl[0:0] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0101111;
-            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})";
+            assembly: {"amomaxu.d", "{name(rd)}, {name(rs1)}, {name(rs2)} (aqu = {aq},rel = {rl})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS];
                 unsigned<64> res1 = MEM[offs];

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -285,7 +285,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFSWSP {
             encoding: 3'b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 2'b10;
-            assembly: {"c.fswsp", "f {rs2}, {uimm}(x2), "};
+            assembly: {"c.fswsp", "f {rs2}, {uimm}(x2)"};
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<32>)F[rs2];
@@ -335,7 +335,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFSDSP {//(RV32/64)
             encoding: 3'b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 2'b10;
-            assembly: {"c.fsdsp", "f {rs2}, {uimm}(x2), "};
+            assembly: {"c.fsdsp", "f {rs2}, {uimm}(x2)"};
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<64>)F[rs2];

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -246,7 +246,7 @@ InstructionSet RV32FC extends RV32F {
     instructions {
         CFLW {
             encoding: 3'b011 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 2'b00;
-            assembly:"f(8+{rd}), {uimm}({name(8+rs1)})";
+            assembly: "f(8+{rd}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8]+uimm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -260,7 +260,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFSW {
             encoding: 3'b111 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 2'b00;
-            assembly:"f(8+{rs2}), {uimm}({name(8+rs1)})";
+            assembly: "f(8+{rs2}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 MEM[offs] = (unsigned<32>)F[rs2 + 8];
@@ -269,7 +269,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFLWSP {
             encoding: 3'b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 2'b10;
-            assembly:"f {rd}, {uimm}(x2)";
+            assembly: "f {rd}, {uimm}(x2)";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -283,7 +283,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFSWSP {
             encoding: 3'b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 2'b10;
-            assembly:"f {rs2}, {uimm}(x2), ";
+            assembly: "f {rs2}, {uimm}(x2), ";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<32>)F[rs2];
@@ -296,7 +296,7 @@ InstructionSet RV32DC extends RV32D {
     instructions {
         CFLD { //(RV32/64)
             encoding: 3'b001 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
-            assembly:"f(8+{rd}), {uimm}({name(8+rs1)})";
+            assembly: "f(8+{rd}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
@@ -310,7 +310,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFSD { //(RV32/64)
             encoding: 3'b101 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
-            assembly:"f(8+{rs2}), {uimm}({name(8+rs1)})";
+            assembly: "f(8+{rs2}), {uimm}({name(8+rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 MEM[offs] = (unsigned<64>)F[rs2 + 8];
@@ -319,7 +319,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFLDSP {//(RV32/64)
             encoding: 3'b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 2'b10;
-            assembly:"f {rd}, {uimm}(x2)";
+            assembly: "f {rd}, {uimm}(x2)";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
@@ -333,7 +333,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFSDSP {//(RV32/64)
             encoding: 3'b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 2'b10;
-            assembly:"f {rs2}, {uimm}(x2), ";
+            assembly: "f {rs2}, {uimm}(x2), ";
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<64>)F[rs2];

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -10,7 +10,7 @@ InstructionSet RV32IC extends RV32I {
     instructions{
         CADDI4SPN { //(RES, imm=0)
             encoding: 3'b000 :: imm[5:4] :: imm[9:6] :: imm[2:2] :: imm[3:3] :: rd[2:0] :: 2'b00;
-            assembly: "{name(8+rd)}, {imm:#05x}";
+            assembly: {"c.addi4spn", "{name(8+rd)}, {imm:#05x}"};
             behavior:
                 if (imm) X[rd + 8] = X[2] + imm;
                 else raise(0, 2);
@@ -18,7 +18,7 @@ InstructionSet RV32IC extends RV32I {
 
         CLW { // (RV32)
             encoding: 3'b010 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 2'b00;
-            assembly: "{name(8+rd)}, {uimm:#05x}({name(8+rs1)})";
+            assembly: {"c.lw", "{name(8+rd)}, {uimm:#05x}({name(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> load_address = X[rs1 + 8] + uimm;
                 X[rd + 8] = (signed<32>)MEM[load_address];
@@ -27,7 +27,7 @@ InstructionSet RV32IC extends RV32I {
 
         CSW {//(RV32)
             encoding: 3'b110 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 2'b00;
-            assembly: "{name(8+rs2)}, {uimm:#05x}({name(8+rs1)})";
+            assembly: {"c.sw", "{name(8+rs2)}, {uimm:#05x}({name(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> load_address = X[rs1 + 8] + uimm;
                 MEM[load_address] = (signed<32>)X[rs2 + 8];
@@ -36,12 +36,13 @@ InstructionSet RV32IC extends RV32I {
 
         CADDI {//(RV32)
             encoding: 3'b000 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 2'b01;
-            assembly: "{name(rs1)}, {imm:#05x}";
+            assembly: {"c.addi", "{name(rs1)}, {imm:#05x}"};
             behavior: if(rs1 >= RFS) raise(0, 2); else if (rs1 != 0) X[rs1] = X[rs1] + (signed<6>)imm;
         }
 
         CNOP {
             encoding: 3'b000 :: nzimm[5:5] :: 5'b00000 :: nzimm[4:0] :: 2'b01;
+            assembly: {"c.nop", ""};
             behavior: {
                 //if (!nzimm) raise(0, 2);
             }
@@ -50,7 +51,7 @@ InstructionSet RV32IC extends RV32I {
         // CJAL will be overwritten by CADDIW for RV64/128
         CJAL [[no_cont]] {//(RV32)
             encoding: 3'b001 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 2'b01;
-            assembly: "{imm:#05x}";
+            assembly: {"c.jal", "{imm:#05x}"};
             behavior: {
                 X[1] = PC + 2;
                 PC = PC + (signed<12>)imm;
@@ -59,7 +60,7 @@ InstructionSet RV32IC extends RV32I {
 
         CLI {//(RV32)
             encoding: 3'b010 :: imm[5:5] :: rd[4:0] :: imm[4:0] :: 2'b01;
-            assembly: "{name(rd)}, {imm:#05x}";
+            assembly: {"c.li", "{name(rd)}, {imm:#05x}"};
             behavior: if(rd >= RFS) raise(0, 2); else {
                 if (rd != 0) X[rd] = (signed<6>)imm;
             }
@@ -68,7 +69,7 @@ InstructionSet RV32IC extends RV32I {
         // order matters here as CADDI16SP overwrites CLUI for rd == 2
         CLUI {//(RV32)
             encoding: 3'b011 :: imm[17:17] :: rd[4:0] :: imm[16:12] :: 2'b01;
-            assembly: "{name(rd)}, {imm:#05x}";
+            assembly: {"c.lui", "{name(rd)}, {imm:#05x}"};
             behavior: {
                 if (imm == 0 || rd >= RFS) raise(0, 2);
                 if (rd != 0) X[rd] = (signed<18>)imm;
@@ -77,7 +78,7 @@ InstructionSet RV32IC extends RV32I {
 
         CADDI16SP {//(RV32)
             encoding: 3'b011 :: nzimm[9:9] :: 5'b00010 :: nzimm[4:4] :: nzimm[6:6] :: nzimm[8:7] :: nzimm[5:5] :: 2'b01;
-            assembly: "{nzimm:#05x}";
+            assembly: {"c.addi16sp", "{nzimm:#05x}"};
             behavior:
                 if (nzimm) X[2] = X[2] + (signed<10>)nzimm;
                 else raise(0, 2);
@@ -90,7 +91,7 @@ InstructionSet RV32IC extends RV32I {
 
         CSRLI {//(RV32 nse)
             encoding: 3'b100 :: 1'b0 :: 2'b00 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
-            assembly: "{name(8+rs1)}, {shamt}";
+            assembly: {"c.srli", "{name(8+rs1)}, {shamt}"};
             behavior: {
                 X[rs1 + 8] = X[rs1 + 8] >> shamt;
             }
@@ -98,7 +99,7 @@ InstructionSet RV32IC extends RV32I {
 
         CSRAI {//(RV32)
             encoding: 3'b100 :: 1'b0 :: 2'b01 :: rs1[2:0] :: shamt[4:0] :: 2'b01;
-            assembly: "{name(8+rs1)}, {shamt}";
+            assembly: {"c.srai", "{name(8+rs1)}, {shamt}"};
             behavior: {
                 if (shamt) {
                     X[rs1 + 8] = ((signed<XLEN>)X[rs1 + 8]) >> shamt;
@@ -110,7 +111,7 @@ InstructionSet RV32IC extends RV32I {
 
         CANDI {//(RV32)
             encoding: 3'b100 :: imm[5:5] :: 2'b10 :: rs1[2:0] :: imm[4:0] :: 2'b01;
-            assembly: "{name(8+rs1)}, {imm:#05x}";
+            assembly: {"c.andi", "{name(8+rs1)}, {imm:#05x}"};
             behavior: {
                 X[rs1 + 8] = X[rs1 + 8] & (signed<6>)imm;
             }
@@ -118,7 +119,7 @@ InstructionSet RV32IC extends RV32I {
 
         CSUB {//(RV32)
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b00 :: rs2[2:0] :: 2'b01;
-            assembly: "{name(8+rd)}, {name(8+rs2)}";
+            assembly: {"c.sub", "{name(8+rd)}, {name(8+rs2)}"};
             behavior: {
                 X[rd + 8] = X[rd + 8] - X[rs2 + 8];
             }
@@ -126,7 +127,7 @@ InstructionSet RV32IC extends RV32I {
 
         CXOR {//(RV32)
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b01 :: rs2[2:0] :: 2'b01;
-            assembly: "{name(8+rd)}, {name(8+rs2)}";
+            assembly: {"c.xor", "{name(8+rd)}, {name(8+rs2)}"};
             behavior: {
                 X[rd + 8] = X[rd + 8] ^ X[rs2 + 8];
             }
@@ -134,7 +135,7 @@ InstructionSet RV32IC extends RV32I {
 
         COR {//(RV32)
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b10 :: rs2[2:0] :: 2'b01;
-            assembly: "{name(8+rd)}, {name(8+rs2)}";
+            assembly: {"c.or", "{name(8+rd)}, {name(8+rs2)}"};
             behavior: {
                 X[rd + 8] = X[rd + 8] | X[rs2 + 8];
             }
@@ -142,7 +143,7 @@ InstructionSet RV32IC extends RV32I {
 
         CAND {//(RV32)
             encoding: 3'b100 :: 1'b0 :: 2'b11 :: rd[2:0] :: 2'b11 :: rs2[2:0] :: 2'b01;
-            assembly: "{name(8+rd)}, {name(8+rs2)}";
+            assembly: {"c.and", "{name(8+rd)}, {name(8+rs2)}"};
             behavior: {
                 X[rd + 8] = X[rd + 8] & X[rs2 + 8];
             }
@@ -150,49 +151,49 @@ InstructionSet RV32IC extends RV32I {
 
         CJ [[no_cont]] {//(RV32)
             encoding: 3'b101 :: imm[11:11] :: imm[4:4] :: imm[9:8] :: imm[10:10] :: imm[6:6] :: imm[7:7] :: imm[3:1] :: imm[5:5] :: 2'b01;
-            assembly: "{imm:#05x}";
+            assembly: {"c.j", "{imm:#05x}"};
             behavior: PC = PC + (signed<12>)imm;
         }
 
         CBEQZ [[no_cont]] [[cond]] {//(RV32)
             encoding: 3'b110 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 2'b01;
-            assembly: "{name(8+rs1)}, {imm:#05x}";
+            assembly: {"c.beqz", "{name(8+rs1)}, {imm:#05x}"};
             behavior: if (X[rs1 + 8] == 0) PC = PC + (signed<9>)imm;
         }
 
         CBNEZ [[no_cont]] [[cond]] {//(RV32)
             encoding: 3'b111 :: imm[8:8] :: imm[4:3] :: rs1[2:0] :: imm[7:6] :: imm[2:1] :: imm[5:5] :: 2'b01;
-            assembly: "{name(8+rs1)}, {imm:#05x}";
+            assembly: {"c.bnez", "{name(8+rs1)}, {imm:#05x}"};
             behavior: if (X[rs1 + 8] != 0) PC = PC + (signed<9>)imm;
         }
 
         CSLLI {//(RV32)
             encoding: 3'b000 :: 1'b0 :: rs1[4:0] :: nzuimm[4:0] :: 2'b10;
-            assembly: "{name(rs1)}, {nzuimm}";
+            assembly: {"c.slli", "{name(rs1)}, {nzuimm}"};
             behavior: if(rs1 >= RFS || nzuimm == 0) raise(0, 2); else  if(rs1 != 0) X[rs1] = X[rs1] << nzuimm;
         }
 
         CLWSP {//
             encoding: 3'b010 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 2'b10;
-            assembly: "{name(rd)}, sp, {uimm:#05x}";
+            assembly: {"c.clwsp", "{name(rd)}, sp, {uimm:#05x}"};
             behavior: {
                 if(rd >= RFS || rd == 0) raise(0, 2); else {
                     signed<32> res = MEM[X[2] + uimm];
                     X[rd] = (signed<XLEN>)res;
-                } 
+                }
             }
         }
 
         // order matters as CJR is a special case of CMV
         CMV {//(RV32)
             encoding: 3'b100 :: 1'b0 :: rd[4:0] :: rs2[4:0] :: 2'b10;
-            assembly: "{name(rd)}, {name(rs2)}";
+            assembly: {"c.mv", "{name(rd)}, {name(rs2)}"};
             behavior: if(rd >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rs2];
         }
 
         CJR [[no_cont]] {//(RV32)
             encoding: 3'b100 :: 1'b0 :: rs1[4:0] :: 5'b00000 :: 2'b10;
-            assembly: "{name(rs1)}";
+            assembly: {"c.jr", "{name(rs1)}"};
             behavior: if (rs1 && rs1 < RFS)
                 PC = X[rs1 % RFS] & ~0x1;
             else
@@ -207,13 +208,13 @@ InstructionSet RV32IC extends RV32I {
         // order matters as CEBREAK is a special case of CJALR which is a special case of CADD
         CADD {//(RV32)
             encoding: 3'b100 :: 1'b1 :: rd[4:0] :: rs2[4:0] :: 2'b10;
-            assembly: "{name(rd)}, {name(rs2)}";
+            assembly: {"c.add", "{name(rd)}, {name(rs2)}"};
             behavior: if(rd >= RFS) raise(0, 2); else if (rd != 0) X[rd] = X[rd] + X[rs2];
         }
 
         CJALR [[no_cont]] {//(RV32)
             encoding: 3'b100 :: 1'b1 :: rs1[4:0] :: 5'b00000 :: 2'b10;
-            assembly: "{name(rs1)}";
+            assembly: {"c.jalr", "{name(rs1)}"};
             behavior: if(rs1 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> new_pc = X[rs1];
                 X[1] = PC + 2;
@@ -223,12 +224,13 @@ InstructionSet RV32IC extends RV32I {
 
         CEBREAK [[no_cont]] {//(RV32)
             encoding: 3'b100 :: 1'b1 :: 5'b00000 :: 5'b00000 :: 2'b10;
+            assembly: {"c.ebreak", ""};
             behavior: raise(0, 3);
         }
 
         CSWSP {//
             encoding: 3'b110 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 2'b10;
-            assembly: "{name(rs2)}, {uimm:#05x}(sp)";
+            assembly: {"c.swsp", "{name(rs2)}, {uimm:#05x}(sp)"};
             behavior: if(rs2 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<32>)X[rs2];
@@ -246,7 +248,7 @@ InstructionSet RV32FC extends RV32F {
     instructions {
         CFLW {
             encoding: 3'b011 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 2'b00;
-            assembly: "f(8+{rd}), {uimm}({name(8+rs1)})";
+            assembly: {"c.flw", "f(8+{rd}), {uimm}({name(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8]+uimm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -260,7 +262,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFSW {
             encoding: 3'b111 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 2'b00;
-            assembly: "f(8+{rs2}), {uimm}({name(8+rs1)})";
+            assembly: {"c.fsw", "f(8+{rs2}), {uimm}({name(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 MEM[offs] = (unsigned<32>)F[rs2 + 8];
@@ -269,7 +271,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFLWSP {
             encoding: 3'b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 2'b10;
-            assembly: "f {rd}, {uimm}(x2)";
+            assembly: {"c.flwsp", "f {rd}, {uimm}(x2)"};
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -283,7 +285,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFSWSP {
             encoding: 3'b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 2'b10;
-            assembly: "f {rs2}, {uimm}(x2), ";
+            assembly: {"c.fswsp", "f {rs2}, {uimm}(x2), "};
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<32>)F[rs2];
@@ -296,7 +298,7 @@ InstructionSet RV32DC extends RV32D {
     instructions {
         CFLD { //(RV32/64)
             encoding: 3'b001 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
-            assembly: "f(8+{rd}), {uimm}({name(8+rs1)})";
+            assembly: {"c.fld", "f(8+{rd}), {uimm}({name(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
@@ -310,7 +312,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFSD { //(RV32/64)
             encoding: 3'b101 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
-            assembly: "f(8+{rs2}), {uimm}({name(8+rs1)})";
+            assembly: {"c.fsd", "f(8+{rs2}), {uimm}({name(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 MEM[offs] = (unsigned<64>)F[rs2 + 8];
@@ -319,7 +321,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFLDSP {//(RV32/64)
             encoding: 3'b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 2'b10;
-            assembly: "f {rd}, {uimm}(x2)";
+            assembly: {"c.fldsp", "f {rd}, {uimm}(x2)"};
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
@@ -333,7 +335,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFSDSP {//(RV32/64)
             encoding: 3'b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 2'b10;
-            assembly: "f {rs2}, {uimm}(x2), ";
+            assembly: {"c.fsdsp", "f {rs2}, {uimm}(x2), "};
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<64>)F[rs2];
@@ -346,7 +348,7 @@ InstructionSet RV64IC extends RV32IC {
     instructions{
         CSRLI {//(RV32/RV64)
             encoding: 3'b100:: nzuimm[5:5] :: 2'b00:: rs1[2:0] :: nzuimm[4:0] :: 2'b01;
-            assembly: "{name(8+rs1)}, {nzuimm}";
+            assembly: {"c.srli", "{name(8+rs1)}, {nzuimm}"};
             behavior: {
                 X[rs1 + 8] = X[rs1 + 8] >> nzuimm;
             }
@@ -354,7 +356,7 @@ InstructionSet RV64IC extends RV32IC {
 
         CSRAI {//(RV32/RV64)
             encoding: 3'b100:: shamt[5:5] :: 2'b01:: rs1[2:0] :: shamt[4:0] :: 2'b01;
-            assembly: "{name(8+rs1)}, {shamt}";
+            assembly: {"c.srai", "{name(8+rs1)}, {shamt}"};
             behavior: {
                 X[rs1 + 8] = ((signed<XLEN>)X[rs1 + 8]) >> shamt;
             }
@@ -362,7 +364,7 @@ InstructionSet RV64IC extends RV32IC {
 
         CSLLI {//(RV32/RV64)
             encoding: 3'b000:: shamt[5:5] :: rs1[4:0] :: shamt[4:0] :: 2'b10;
-            assembly: "{name(rs1)}, {shamt}";
+            assembly: {"c.slli", "{name(rs1)}, {shamt}"};
             behavior: {
                 if(rs1 == 0 || rs1 >= RFS) raise(0, 2);
                 X[rs1] = X[rs1] << shamt;
@@ -371,7 +373,7 @@ InstructionSet RV64IC extends RV32IC {
 
         CLD {//(RV64/128)
             encoding: 3'b011:: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
-            assembly: "{name(8+rd)}, {uimm},({name(8+rs1)})";
+            assembly: {"c.ld", "{name(8+rd)}, {uimm},({name(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 X[rd + 8] = (signed<64>)MEM[offs];
@@ -380,7 +382,7 @@ InstructionSet RV64IC extends RV32IC {
 
         CSD { //(RV64/128)
             encoding: 3'b111:: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
-            assembly: "{name(8+rs2)}, {uimm},({name(8+rs1)})";
+            assembly: {"c.sd", "{name(8+rs2)}, {uimm},({name(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 MEM[offs]= (unsigned<64>)X[rs2 + 8];
@@ -389,7 +391,7 @@ InstructionSet RV64IC extends RV32IC {
 
         CSUBW {//(RV64/128, RV32 res)
             encoding: 3'b100 :: 0b1 :: 2'b11:: rd[2:0] :: 2'b00:: rs2[2:0] :: 2'b01;
-            assembly: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
+            assembly: {"c.subw", "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}"};
             behavior: {
                 signed<32> res = (signed<32>)X[rd + 8] - (signed<32>)X[rs2 + 8];
                 X[rd + 8] = (signed<XLEN>)res;
@@ -398,7 +400,7 @@ InstructionSet RV64IC extends RV32IC {
 
         CADDW {//(RV64/128 RV32 res)
             encoding: 3'b100 :: 0b1 :: 2'b11:: rd[2:0] :: 2'b01:: rs2[2:0] :: 2'b01;
-            assembly: "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}";
+            assembly: {"c.addw", "{name(8+rd)}, {name(8+rd)}, {name(8+rs2)}"};
             behavior: {
 	            signed<32> res = (signed<32>)X[rd + 8] + (signed<32>)X[rs2 + 8];
 	            X[rd + 8] = (signed<XLEN>)res;
@@ -407,13 +409,13 @@ InstructionSet RV64IC extends RV32IC {
 
         CADDIW {//(RV64/128)
             encoding: 3'b001 :: imm[5:5] :: rs1[4:0] :: imm[4:0] :: 2'b01;
-            assembly: "{name(rs1)}, {imm:#05x}";
+            assembly: {"c.addiw", "{name(rs1)}, {imm:#05x}"};
             behavior: if(rs1 >= RFS || rs1 == 0) raise(0, 2); else if (rs1 != 0) X[rs1] = (signed<32>)X[rs1] + (signed<6>)imm;
         }
 
         CLDSP {//(RV64/128
             encoding: 3'b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 2'b10;
-            assembly: "{name(rd)}, {uimm}(sp)";
+            assembly: {"c.ldsp", "{name(rd)}, {uimm}(sp)"};
             behavior: if(rd >= RFS || rd == 0) raise(0, 2); else {
                 unsigned<XLEN> res = MEM[X[2] + uimm];
                 X[rd] = res;
@@ -422,7 +424,7 @@ InstructionSet RV64IC extends RV32IC {
 
         CSDSP {//(RV64/128)
             encoding: 3'b111 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 2'b10;
-            assembly: "{name(rs2)}, {uimm}(sp)";
+            assembly: {"c.sdsp", "{name(rs2)}, {uimm}(sp)"};
             behavior: if(rs2 >= RFS) raise(0, 2); else {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<64>)X[rs2];
@@ -435,21 +437,21 @@ InstructionSet RV128IC extends RV64IC {
     instructions{
         CSRAI64 {//(RV128)
             encoding: 3'b100 :: 0b0 :: 2'b01:: rs1[2:0] :: 0b0000 :: 2'b01;
-            assembly: "{name(8+rs1)}";
+            assembly: {"c.srai64", "{name(8+rs1)}"};
             behavior: {
                 X[rs1 + 8] = (signed<XLEN>)X[rs1 + 8] >> 64;
             }
         }
         CSRLI64 {//(RV128)
             encoding: 0b1000 :: 2'b00:: rs1[2:0] :: 00000 :: 2'b01;
-            assembly: "{name(8+rs1)}";
+            assembly: {"c.srli64", "{name(8+rs1)}"};
             behavior: {
                 X[rs1 + 8] = X[rs1 + 8] << 64;
             }
         }
         CSLLI64 {//(RV128)
             encoding: 3'b000:: 0b0 :: rs1[4:0] :: 0b0000 :: 2'b10;
-            assembly: "{name(rs1)}";
+            assembly: {"c.slli64", "{name(rs1)}"};
             behavior: {
                 if(rs1 == 0) raise(0, 2);
                 X[rs1] = X[rs1] << 64;
@@ -457,14 +459,17 @@ InstructionSet RV128IC extends RV64IC {
         }
         CLQ { //(RV128)
              encoding: 3'b001:: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
+            assembly: {"c.lq", "{name(8+rd)}, {uimm:#05x}({name(8+rs1)})"};
              behavior: {}
         }
         CSQ { //(RV128)
             encoding: 3'b101:: uimm[5:4] :: uimm[8:8] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
+            assembly: {"c.sq", "{name(8+rs2)}, {uimm:#05x}({name(8+rs1)})"};
             behavior: {}
         }
         CSQSP {//(RV128)
             encoding: 3'b101:: uimm[5:4] :: uimm[9:6] :: rs2[4:0] :: 2'b10;
+            assembly: {"c.sqsp", "{name(8+rs2)}, {uimm:#05x}(x2)"};
             behavior: {}
         }
     }

--- a/RVC.core_desc
+++ b/RVC.core_desc
@@ -248,7 +248,7 @@ InstructionSet RV32FC extends RV32F {
     instructions {
         CFLW {
             encoding: 3'b011 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rd[2:0] :: 2'b00;
-            assembly: {"c.flw", "f(8+{rd}), {uimm}({name(8+rs1)})"};
+            assembly: {"c.flw", "{fname(8+rd)}, {uimm}({name(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8]+uimm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -262,7 +262,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFSW {
             encoding: 3'b111 :: uimm[5:3] :: rs1[2:0] :: uimm[2:2] :: uimm[6:6] :: rs2[2:0] :: 2'b00;
-            assembly: {"c.fsw", "f(8+{rs2}), {uimm}({name(8+rs1)})"};
+            assembly: {"c.fsw", "{fname(8+rs2)}, {uimm}({name(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 MEM[offs] = (unsigned<32>)F[rs2 + 8];
@@ -271,7 +271,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFLWSP {
             encoding: 3'b011 :: uimm[5:5] :: rd[4:0] :: uimm[4:2] :: uimm[7:6] :: 2'b10;
-            assembly: {"c.flwsp", "f {rd}, {uimm}(x2)"};
+            assembly: {"c.flwsp", "{fname(rd)}, {uimm}(x2)"};
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -285,7 +285,7 @@ InstructionSet RV32FC extends RV32F {
 
         CFSWSP {
             encoding: 3'b111 :: uimm[5:2] :: uimm[7:6] :: rs2[4:0] :: 2'b10;
-            assembly: {"c.fswsp", "f {rs2}, {uimm}(x2)"};
+            assembly: {"c.fswsp", "{fname(rs2)}, {uimm}(x2)"};
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<32>)F[rs2];
@@ -298,7 +298,7 @@ InstructionSet RV32DC extends RV32D {
     instructions {
         CFLD { //(RV32/64)
             encoding: 3'b001 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rd[2:0] :: 2'b00;
-            assembly: {"c.fld", "f(8+{rd}), {uimm}({name(8+rs1)})"};
+            assembly: {"c.fld", "{fname(8+rd)}, {uimm}({name(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
@@ -312,7 +312,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFSD { //(RV32/64)
             encoding: 3'b101 :: uimm[5:3] :: rs1[2:0] :: uimm[7:6] :: rs2[2:0] :: 2'b00;
-            assembly: {"c.fsd", "f(8+{rs2}), {uimm}({name(8+rs1)})"};
+            assembly: {"c.fsd", "{fname(8+rs2)}, {uimm}({fname(8+rs1)})"};
             behavior: {
                 unsigned<XLEN> offs = X[rs1 + 8] + uimm;
                 MEM[offs] = (unsigned<64>)F[rs2 + 8];
@@ -321,7 +321,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFLDSP {//(RV32/64)
             encoding: 3'b001 :: uimm[5:5] :: rd[4:0] :: uimm[4:3] :: uimm[8:6] :: 2'b10;
-            assembly: {"c.fldsp", "f {rd}, {uimm}(x2)"};
+            assembly: {"c.fldsp", "{fname(rd)}, {uimm}(x2)"};
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
@@ -335,7 +335,7 @@ InstructionSet RV32DC extends RV32D {
 
         CFSDSP {//(RV32/64)
             encoding: 3'b101 :: uimm[5:3] :: uimm[8:6] :: rs2[4:0] :: 2'b10;
-            assembly: {"c.fsdsp", "f {rs2}, {uimm}(x2)"};
+            assembly: {"c.fsdsp", "{fname(rs2)}, {uimm}(x2)"};
             behavior: {
                 unsigned<XLEN> offs = X[2] + uimm;
                 MEM[offs] = (unsigned<64>)F[rs2];

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -25,7 +25,7 @@ InstructionSet RV32D extends RV32F {
     instructions {
         FLD {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0000111;
-            assembly: "f {rd}, {imm}({name(rs1)})";
+            assembly: "{fname(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
@@ -39,7 +39,7 @@ InstructionSet RV32D extends RV32F {
 
         FSD {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: imm[4:0] :: 7'b0100111;
-            assembly: "f {rs2}, {imm}({name(rs1)})";
+            assembly: "{fname(rs2)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 MEM[offs] = (unsigned<64>)F[rs2];
@@ -48,7 +48,7 @@ InstructionSet RV32D extends RV32F {
 
         FMADD_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000011;
-            assembly: {"fmadd.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}"};
+            assembly: {"fmadd.d", "{name(rm)}, {name(rd)}, {fname(rs1)}, {fname(rs2)}, {fname(rs3)}"};
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f + F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 0, rm<7? rm: (unsigned char)FCSR);
@@ -64,7 +64,7 @@ InstructionSet RV32D extends RV32F {
 
         FMSUB_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000111;
-            assembly: {"fmsub.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}"};
+            assembly: {"fmsub.d", "{name(rm)}, {name(rd)}, {fname(rs1)}, {fname(rs2)}, {fname(rs3)}"};
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f - F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 1, rm<7? rm: (unsigned char)FCSR);
@@ -80,7 +80,7 @@ InstructionSet RV32D extends RV32F {
 
         FNMADD_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001111;
-            assembly: {"fnmadd.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}"};
+            assembly: {"fnmadd.d", "{name(rm)}, {name(rd)}, {fname(rs1)}, {fname(rs2)}, {fname(rs3)}"};
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f + F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 2, rm<7? rm: (unsigned char)FCSR);
@@ -96,7 +96,7 @@ InstructionSet RV32D extends RV32F {
 
         FNMSUB_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001011;
-            assembly: {"fnmsub.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}"};
+            assembly: {"fnmsub.d", "{name(rm)}, {name(rd)}, {fname(rs1)}, {fname(rs2)}, {fname(rs3)}"};
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f - F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 3, rm<7? rm: (unsigned char)FCSR);
@@ -112,7 +112,7 @@ InstructionSet RV32D extends RV32F {
 
         FADD_D {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fadd.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}"};
+            assembly: {"fadd.d", "{name(rm)}, {name(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
                 unsigned<64> res = fadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -128,7 +128,7 @@ InstructionSet RV32D extends RV32F {
 
         FSUB_D {
             encoding: 7'b0000101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fsub.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}"};
+            assembly: {"fsub.d", "{name(rm)}, {name(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
                 unsigned<64> res = fsub_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -144,7 +144,7 @@ InstructionSet RV32D extends RV32F {
 
         FMUL_D {
             encoding: 7'b0001001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fmul.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}"};
+            assembly: {"fmul.d", "{name(rm)}, {name(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
                 unsigned<64> res = fmul_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -160,7 +160,7 @@ InstructionSet RV32D extends RV32F {
 
         FDIV_D {
             encoding: 7'b0001101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fdiv.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}"};
+            assembly: {"fdiv.d", "{name(rm)}, {name(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
                 unsigned<64> res = fdiv_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -176,7 +176,7 @@ InstructionSet RV32D extends RV32F {
 
         FSQRT_D {
             encoding: 7'b0101101 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fsqrt.d", "{name(rm)}, {name(rd)}, f {rs1}"};
+            assembly: {"fsqrt.d", "{name(rm)}, {name(rd)}, {fname(rs1)}"};
             behavior: {
                 //F[rd]f = sqrt(F[rs1]f);
                 unsigned<64> res = fsqrt_d((unsigned<64>)F[rs1], rm<7? rm: (unsigned char)FCSR);
@@ -192,7 +192,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJ_D {
             encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fsgnj.d", "f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fsgnj.d", "{fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 unsigned<64> res = F[rs2][63:63] :: F[rs1][62:0];
                 if (FLEN == 64)
@@ -205,7 +205,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJN_D {
             encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fsgnjn.d", "f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fsgnjn.d", "{fname(rd)}, {fname(rs1)}, {fname(rs2})"};
             behavior: {
                 unsigned<64> res = ~F[rs2][63:63] :: F[rs1][62:0];
                 if (FLEN == 64)
@@ -218,7 +218,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJX_D {
             encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fsgnjx.d", "f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fsgnjx.d", "{fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 unsigned<64> res = (unsigned<64>)F[rs1] ^ ((unsigned<64>)F[rs2] & (1 << 63));
                 if (FLEN == 64)
@@ -231,7 +231,7 @@ InstructionSet RV32D extends RV32F {
 
         FMIN_D {
             encoding: 7'b0010101 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fmin.d", "f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fmin.d", "{fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
                 unsigned<64> res = fsel_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 0);
@@ -247,7 +247,7 @@ InstructionSet RV32D extends RV32F {
 
         FMAX_D {
             encoding: 7'b0010101 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fmax.d", "f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fmax.d", "{fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
                 unsigned<64> res = fsel_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 1);
@@ -263,7 +263,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_S_D {
             encoding: 7'b0100000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.s.d", "{name(rm)}, f {rd}, f {rs1}"};
+            assembly: {"fcvt.s.d", "{name(rm)}, {fname(rd)}, {fname(rs1)}"};
             behavior: {
                 unsigned<32> res = fconv_d2f(F[rs1], rm);
                 // NaN boxing
@@ -273,7 +273,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_S {
             encoding: 7'b0100001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.d.s", "{name(rm)}, f {rd}, f {rs1}"};
+            assembly: {"fcvt.d.s", "{name(rm)}, {fname(rd)}, {fname(rs1)}"};
             behavior: {
                 unsigned<64> res = fconv_f2d((unsigned)F[rs1], rm);
                 if (FLEN == 64) {
@@ -286,7 +286,7 @@ InstructionSet RV32D extends RV32F {
 
         FEQ_D {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly: {"feq.d", "{name(rd)}, f {rs1}, f {rs2}"};
+            assembly: {"feq.d", "{name(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 unsigned<64> res = 0;
                 if (FLEN == 64)
@@ -304,7 +304,7 @@ InstructionSet RV32D extends RV32F {
 
         FLT_D {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: {"flt.d", "{name(rd)}, f {rs1}, f {rs2}"};
+            assembly: {"flt.d", "{name(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 unsigned<64> res = 0;
                 if (FLEN == 64)
@@ -322,7 +322,7 @@ InstructionSet RV32D extends RV32F {
 
         FLE_D {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fle.d", "{name(rd)}, f {rs1}, f {rs2}"};
+            assembly: {"fle.d", "{name(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 unsigned<64> res = 0;
                 if (FLEN == 64)
@@ -340,7 +340,7 @@ InstructionSet RV32D extends RV32F {
 
         FCLASS_D {
             encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: {"flass.d", "{name(rd)}, f {rs1}"};
+            assembly: {"flass.d", "{name(rd)}, {fname(rs1)}"};
             behavior: {
                 X[rd % RFS] = fclass_d((unsigned<64>)F[rs1]);
             }
@@ -348,7 +348,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_W_D {
             encoding: 7'b1100001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.w.d", "{name(rm)}, {name(rd)}, f {rs1}"};
+            assembly: {"fcvt.w.d", "{name(rm)}, {name(rd)}, {fname(rs1)}"};
             behavior: {
                 signed<64> res = 0;
                 if (FLEN == 64)
@@ -365,7 +365,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_WU_D {
             encoding: 7'b1100001 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.wu.d", "{name(rm)}, {name(rd)}, f {rs1}"};
+            assembly: {"fcvt.wu.d", "{name(rm)}, {name(rd)}, {fname(rs1)}"};
             behavior: {
                 //FIXME: should be zext accodring to spec but needs to be sext according to tests
                 unsigned<64> res = 0;
@@ -383,7 +383,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_W {
             encoding: 7'b1101001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.d.w", "{name(rm)}, f {rd}, {name(rs1)}"};
+            assembly: {"fcvt.d.w", "{name(rm)}, {fname(rd)}, {name(rs1)}"};
             behavior: {
                 signed<64> res = fcvt_32_64((unsigned)X[rs1 % RFS], 2, rm);
                 if (FLEN == 64)
@@ -396,7 +396,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_WU {
             encoding: 7'b1101001 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.d.wu", "{name(rm)}, f {rd}, {name(rs1)}"};
+            assembly: {"fcvt.d.wu", "{name(rm)}, {fname(rd)}, {name(rs1)}"};
             behavior: {
                 unsigned<64> res = fcvt_32_64((unsigned)X[rs1 % RFS], 3, rm);
                 if (FLEN == 64)
@@ -413,7 +413,7 @@ InstructionSet RV64D extends RV32D {
     instructions {
         FCVT_L_D {
             encoding: 7'b1100001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.l.d", "{name(rm)}, {name(rd)}, f {rs1}"};
+            assembly: {"fcvt.l.d", "{name(rm)}, {name(rd)}, {fname(rs1)}"};
             behavior: {
                 X[rd % RFS] = fcvt_d((unsigned<64>)F[rs1], 0, rm);
                 unsigned<32> flags = fget_flags();
@@ -423,7 +423,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_LU_D {
             encoding: 7'b1100001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.lu.d", "{name(rm)}, {name(rd)}, f {rs1}"};
+            assembly: {"fcvt.lu.d", "{name(rm)}, {name(rd)}, {fname(rs1)}"};
             behavior: {
                 X[rd % RFS] = fcvt_d((unsigned<64>)F[rs1], 1, rm);
                 unsigned<32> flags = fget_flags();
@@ -433,7 +433,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_D_L {
             encoding: 7'b1101001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.d.l", "{name(rm)}, f {rd}, {name(rs1)}"};
+            assembly: {"fcvt.d.l", "{name(rm)}, {fname(rd)}, {name(rs1)}"};
             behavior: {
                 unsigned<64> res = fcvt_d(X[rs1 % RFS], 2, rm);
                 if (FLEN == 64)
@@ -446,7 +446,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_D_LU {
             encoding: 7'b1101001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.d.lu", "{name(rm)}, f {rd}, {name(rs1)}"};
+            assembly: {"fcvt.d.lu", "{name(rm)}, {fname(rd)}, {name(rs1)}"};
             behavior: {
                 unsigned<64> res = fcvt_d(X[rs1 % RFS], 3, rm);
                 if (FLEN == 64)
@@ -459,7 +459,7 @@ InstructionSet RV64D extends RV32D {
 
         FMV_X_D {
             encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fmv.x.d", "{name(rd)}, f {rs1}"};
+            assembly: {"fmv.x.d", "{name(rd)}, {fname(rs1)}"};
             behavior: {
                 X[rd % RFS] = F[rs1]; //FIXME: sign extend
             }
@@ -467,7 +467,7 @@ InstructionSet RV64D extends RV32D {
 
         FMV_D_X {
             encoding: 7'b1111001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fmv.d.x", "f {rd}, {name(rs1)}"};
+            assembly: {"fmv.d.x", "{fname(rd)}, {name(rs1)}"};
             behavior: {
                 F[rd] = X[rs1 % RFS];
             }

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -25,7 +25,7 @@ InstructionSet RV32D extends RV32F {
     instructions {
         FLD {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0000111;
-            assembly:"f {rd}, {imm}({name(rs1)})";
+            assembly: "f {rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 unsigned<64> res = (unsigned<64>)MEM[offs];
@@ -39,7 +39,7 @@ InstructionSet RV32D extends RV32F {
 
         FSD {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: imm[4:0] :: 7'b0100111;
-            assembly:"f {rs2}, {imm}({name(rs1)})";
+            assembly: "f {rs2}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 MEM[offs] = (unsigned<64>)F[rs2];
@@ -48,7 +48,7 @@ InstructionSet RV32D extends RV32F {
 
         FMADD_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f + F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 0, rm<7? rm: (unsigned char)FCSR);
@@ -64,7 +64,7 @@ InstructionSet RV32D extends RV32F {
 
         FMSUB_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000111;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f - F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 1, rm<7? rm: (unsigned char)FCSR);
@@ -80,7 +80,7 @@ InstructionSet RV32D extends RV32F {
 
         FNMADD_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001111;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f + F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 2, rm<7? rm: (unsigned char)FCSR);
@@ -96,7 +96,7 @@ InstructionSet RV32D extends RV32F {
 
         FNMSUB_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f - F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 3, rm<7? rm: (unsigned char)FCSR);
@@ -112,7 +112,7 @@ InstructionSet RV32D extends RV32F {
 
         FADD_D {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
                 unsigned<64> res = fadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -128,7 +128,7 @@ InstructionSet RV32D extends RV32F {
 
         FSUB_D {
             encoding: 7'b0000101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
                 unsigned<64> res = fsub_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -144,7 +144,7 @@ InstructionSet RV32D extends RV32F {
 
         FMUL_D {
             encoding: 7'b0001001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
                 unsigned<64> res = fmul_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -160,7 +160,7 @@ InstructionSet RV32D extends RV32F {
 
         FDIV_D {
             encoding: 7'b0001101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
                 unsigned<64> res = fdiv_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -176,7 +176,7 @@ InstructionSet RV32D extends RV32F {
 
         FSQRT_D {
             encoding: 7'b0101101 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //F[rd]f = sqrt(F[rs1]f);
                 unsigned<64> res = fsqrt_d((unsigned<64>)F[rs1], rm<7? rm: (unsigned char)FCSR);
@@ -192,7 +192,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJ_D {
             encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, f {rs1}, f {rs2}";
+            assembly: "f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = F[rs2][63:63] :: F[rs1][62:0];
                 if (FLEN == 64)
@@ -205,7 +205,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJN_D {
             encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, f {rs1}, f {rs2}";
+            assembly: "f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = ~F[rs2][63:63] :: F[rs1][62:0];
                 if (FLEN == 64)
@@ -218,7 +218,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJX_D {
             encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, f {rs1}, f {rs2}";
+            assembly: "f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = (unsigned<64>)F[rs1] ^ ((unsigned<64>)F[rs2] & (1 << 63));
                 if (FLEN == 64)
@@ -231,7 +231,7 @@ InstructionSet RV32D extends RV32F {
 
         FMIN_D {
             encoding: 7'b0010101 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, f {rs1}, f {rs2}";
+            assembly: "f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
                 unsigned<64> res = fsel_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 0);
@@ -247,7 +247,7 @@ InstructionSet RV32D extends RV32F {
 
         FMAX_D {
             encoding: 7'b0010101 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, f {rs1}, f {rs2}";
+            assembly: "f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
                 unsigned<64> res = fsel_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 1);
@@ -263,7 +263,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_S_D {
             encoding: 7'b0100000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, f {rs1}";
+            assembly: "{name(rm)}, f {rd}, f {rs1}";
             behavior: {
                 unsigned<32> res = fconv_d2f(F[rs1], rm);
                 // NaN boxing
@@ -273,7 +273,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_S {
             encoding: 7'b0100001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, f {rs1}";
+            assembly: "{name(rm)}, f {rd}, f {rs1}";
             behavior: {
                 unsigned<64> res = fconv_f2d((unsigned)F[rs1], rm);
                 if (FLEN == 64) {
@@ -286,7 +286,7 @@ InstructionSet RV32D extends RV32F {
 
         FEQ_D {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly: "{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = 0;
                 if (FLEN == 64)
@@ -304,7 +304,7 @@ InstructionSet RV32D extends RV32F {
 
         FLT_D {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly: "{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = 0;
                 if (FLEN == 64)
@@ -322,7 +322,7 @@ InstructionSet RV32D extends RV32F {
 
         FLE_D {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly: "{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<64> res = 0;
                 if (FLEN == 64)
@@ -340,7 +340,7 @@ InstructionSet RV32D extends RV32F {
 
         FCLASS_D {
             encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rd)}, f {rs1}";
+            assembly: "{name(rd)}, f {rs1}";
             behavior: {
                 X[rd % RFS] = fclass_d((unsigned<64>)F[rs1]);
             }
@@ -348,7 +348,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_W_D {
             encoding: 7'b1100001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 signed<64> res = 0;
                 if (FLEN == 64)
@@ -365,7 +365,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_WU_D {
             encoding: 7'b1100001 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //FIXME: should be zext accodring to spec but needs to be sext according to tests
                 unsigned<64> res = 0;
@@ -383,7 +383,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_W {
             encoding: 7'b1101001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 signed<64> res = fcvt_32_64((unsigned)X[rs1 % RFS], 2, rm);
                 if (FLEN == 64)
@@ -396,7 +396,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_WU {
             encoding: 7'b1101001 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<64> res = fcvt_32_64((unsigned)X[rs1 % RFS], 3, rm);
                 if (FLEN == 64)
@@ -413,7 +413,7 @@ InstructionSet RV64D extends RV32D {
     instructions {
         FCVT_L_D {
             encoding: 7'b1100001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 X[rd % RFS] = fcvt_d((unsigned<64>)F[rs1], 0, rm);
                 unsigned<32> flags = fget_flags();
@@ -423,7 +423,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_LU_D {
             encoding: 7'b1100001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 X[rd % RFS] = fcvt_d((unsigned<64>)F[rs1], 1, rm);
                 unsigned<32> flags = fget_flags();
@@ -433,7 +433,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_D_L {
             encoding: 7'b1101001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<64> res = fcvt_d(X[rs1 % RFS], 2, rm);
                 if (FLEN == 64)
@@ -446,7 +446,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_D_LU {
             encoding: 7'b1101001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<64> res = fcvt_d(X[rs1 % RFS], 3, rm);
                 if (FLEN == 64)
@@ -459,7 +459,7 @@ InstructionSet RV64D extends RV32D {
 
         FMV_X_D {
             encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rd)}, f {rs1}";
+            assembly: "{name(rd)}, f {rs1}";
             behavior: {
                 X[rd % RFS] = F[rs1]; //FIXME: sign extend
             }
@@ -467,7 +467,7 @@ InstructionSet RV64D extends RV32D {
 
         FMV_D_X {
             encoding: 7'b1111001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, {name(rs1)}";
+            assembly: "f {rd}, {name(rs1)}";
             behavior: {
                 F[rd] = X[rs1 % RFS];
             }

--- a/RVD.core_desc
+++ b/RVD.core_desc
@@ -48,7 +48,7 @@ InstructionSet RV32D extends RV32F {
 
         FMADD_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: {"fmadd.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}"};
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f + F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 0, rm<7? rm: (unsigned char)FCSR);
@@ -64,7 +64,7 @@ InstructionSet RV32D extends RV32F {
 
         FMSUB_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000111;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: {"fmsub.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}"};
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f - F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 1, rm<7? rm: (unsigned char)FCSR);
@@ -80,7 +80,7 @@ InstructionSet RV32D extends RV32F {
 
         FNMADD_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001111;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: {"fnmadd.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}"};
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f + F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 2, rm<7? rm: (unsigned char)FCSR);
@@ -96,7 +96,7 @@ InstructionSet RV32D extends RV32F {
 
         FNMSUB_D {
             encoding: rs3[4:0] :: 2'b01 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: {"fnmsub.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}"};
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f - F[rs3]f;
                 unsigned<64> res = fmadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], (unsigned<64>)F[rs3], 3, rm<7? rm: (unsigned char)FCSR);
@@ -112,7 +112,7 @@ InstructionSet RV32D extends RV32F {
 
         FADD_D {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly: {"fadd.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}"};
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
                 unsigned<64> res = fadd_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -128,7 +128,7 @@ InstructionSet RV32D extends RV32F {
 
         FSUB_D {
             encoding: 7'b0000101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly: {"fsub.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}"};
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
                 unsigned<64> res = fsub_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -144,7 +144,7 @@ InstructionSet RV32D extends RV32F {
 
         FMUL_D {
             encoding: 7'b0001001 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly: {"fmul.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}"};
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
                 unsigned<64> res = fmul_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -160,7 +160,7 @@ InstructionSet RV32D extends RV32F {
 
         FDIV_D {
             encoding: 7'b0001101 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}";
+            assembly: {"fdiv.d", "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}"};
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
                 unsigned<64> res = fdiv_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], rm<7? rm: (unsigned char)FCSR);
@@ -176,7 +176,7 @@ InstructionSet RV32D extends RV32F {
 
         FSQRT_D {
             encoding: 7'b0101101 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: {"fsqrt.d", "{name(rm)}, {name(rd)}, f {rs1}"};
             behavior: {
                 //F[rd]f = sqrt(F[rs1]f);
                 unsigned<64> res = fsqrt_d((unsigned<64>)F[rs1], rm<7? rm: (unsigned char)FCSR);
@@ -192,7 +192,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJ_D {
             encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fsgnj.d", "f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 unsigned<64> res = F[rs2][63:63] :: F[rs1][62:0];
                 if (FLEN == 64)
@@ -205,7 +205,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJN_D {
             encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fsgnjn.d", "f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 unsigned<64> res = ~F[rs2][63:63] :: F[rs1][62:0];
                 if (FLEN == 64)
@@ -218,7 +218,7 @@ InstructionSet RV32D extends RV32F {
 
         FSGNJX_D {
             encoding: 7'b0010001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fsgnjx.d", "f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 unsigned<64> res = (unsigned<64>)F[rs1] ^ ((unsigned<64>)F[rs2] & (1 << 63));
                 if (FLEN == 64)
@@ -231,7 +231,7 @@ InstructionSet RV32D extends RV32F {
 
         FMIN_D {
             encoding: 7'b0010101 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fmin.d", "f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
                 unsigned<64> res = fsel_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 0);
@@ -247,7 +247,7 @@ InstructionSet RV32D extends RV32F {
 
         FMAX_D {
             encoding: 7'b0010101 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fmax.d", "f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
                 unsigned<64> res = fsel_d((unsigned<64>)F[rs1], (unsigned<64>)F[rs2], 1);
@@ -263,7 +263,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_S_D {
             encoding: 7'b0100000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, f {rs1}";
+            assembly: {"fcvt.s.d", "{name(rm)}, f {rd}, f {rs1}"};
             behavior: {
                 unsigned<32> res = fconv_d2f(F[rs1], rm);
                 // NaN boxing
@@ -273,7 +273,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_S {
             encoding: 7'b0100001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, f {rs1}";
+            assembly: {"fcvt.d.s", "{name(rm)}, f {rd}, f {rs1}"};
             behavior: {
                 unsigned<64> res = fconv_f2d((unsigned)F[rs1], rm);
                 if (FLEN == 64) {
@@ -286,7 +286,7 @@ InstructionSet RV32D extends RV32F {
 
         FEQ_D {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rd)}, f {rs1}, f {rs2}";
+            assembly: {"feq.d", "{name(rd)}, f {rs1}, f {rs2}"};
             behavior: {
                 unsigned<64> res = 0;
                 if (FLEN == 64)
@@ -304,7 +304,7 @@ InstructionSet RV32D extends RV32F {
 
         FLT_D {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rd)}, f {rs1}, f {rs2}";
+            assembly: {"flt.d", "{name(rd)}, f {rs1}, f {rs2}"};
             behavior: {
                 unsigned<64> res = 0;
                 if (FLEN == 64)
@@ -322,7 +322,7 @@ InstructionSet RV32D extends RV32F {
 
         FLE_D {
             encoding: 7'b1010001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rd)}, f {rs1}, f {rs2}";
+            assembly: {"fle.d", "{name(rd)}, f {rs1}, f {rs2}"};
             behavior: {
                 unsigned<64> res = 0;
                 if (FLEN == 64)
@@ -340,7 +340,7 @@ InstructionSet RV32D extends RV32F {
 
         FCLASS_D {
             encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rd)}, f {rs1}";
+            assembly: {"flass.d", "{name(rd)}, f {rs1}"};
             behavior: {
                 X[rd % RFS] = fclass_d((unsigned<64>)F[rs1]);
             }
@@ -348,7 +348,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_W_D {
             encoding: 7'b1100001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: {"fcvt.w.d", "{name(rm)}, {name(rd)}, f {rs1}"};
             behavior: {
                 signed<64> res = 0;
                 if (FLEN == 64)
@@ -365,7 +365,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_WU_D {
             encoding: 7'b1100001 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: {"fcvt.wu.d", "{name(rm)}, {name(rd)}, f {rs1}"};
             behavior: {
                 //FIXME: should be zext accodring to spec but needs to be sext according to tests
                 unsigned<64> res = 0;
@@ -383,7 +383,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_W {
             encoding: 7'b1101001 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: {"fcvt.d.w", "{name(rm)}, f {rd}, {name(rs1)}"};
             behavior: {
                 signed<64> res = fcvt_32_64((unsigned)X[rs1 % RFS], 2, rm);
                 if (FLEN == 64)
@@ -396,7 +396,7 @@ InstructionSet RV32D extends RV32F {
 
         FCVT_D_WU {
             encoding: 7'b1101001 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: {"fcvt.d.wu", "{name(rm)}, f {rd}, {name(rs1)}"};
             behavior: {
                 unsigned<64> res = fcvt_32_64((unsigned)X[rs1 % RFS], 3, rm);
                 if (FLEN == 64)
@@ -413,7 +413,7 @@ InstructionSet RV64D extends RV32D {
     instructions {
         FCVT_L_D {
             encoding: 7'b1100001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: {"fcvt.l.d", "{name(rm)}, {name(rd)}, f {rs1}"};
             behavior: {
                 X[rd % RFS] = fcvt_d((unsigned<64>)F[rs1], 0, rm);
                 unsigned<32> flags = fget_flags();
@@ -423,7 +423,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_LU_D {
             encoding: 7'b1100001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: {"fcvt.lu.d", "{name(rm)}, {name(rd)}, f {rs1}"};
             behavior: {
                 X[rd % RFS] = fcvt_d((unsigned<64>)F[rs1], 1, rm);
                 unsigned<32> flags = fget_flags();
@@ -433,7 +433,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_D_L {
             encoding: 7'b1101001 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: {"fcvt.d.l", "{name(rm)}, f {rd}, {name(rs1)}"};
             behavior: {
                 unsigned<64> res = fcvt_d(X[rs1 % RFS], 2, rm);
                 if (FLEN == 64)
@@ -446,7 +446,7 @@ InstructionSet RV64D extends RV32D {
 
         FCVT_D_LU {
             encoding: 7'b1101001 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: {"fcvt.d.lu", "{name(rm)}, f {rd}, {name(rs1)}"};
             behavior: {
                 unsigned<64> res = fcvt_d(X[rs1 % RFS], 3, rm);
                 if (FLEN == 64)
@@ -459,7 +459,7 @@ InstructionSet RV64D extends RV32D {
 
         FMV_X_D {
             encoding: 7'b1110001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rd)}, f {rs1}";
+            assembly: {"fmv.x.d", "{name(rd)}, f {rs1}"};
             behavior: {
                 X[rd % RFS] = F[rs1]; //FIXME: sign extend
             }
@@ -467,7 +467,7 @@ InstructionSet RV64D extends RV32D {
 
         FMV_D_X {
             encoding: 7'b1111001 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, {name(rs1)}";
+            assembly: {"fmv.d.x", "f {rd}, {name(rs1)}"};
             behavior: {
                 F[rd] = X[rs1 % RFS];
             }

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -30,7 +30,7 @@ InstructionSet RV32F extends Zicsr {
     instructions {
         FLW {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0000111;
-            assembly: "f {rd}, {imm}({name(rs1)})";
+            assembly: "{fname(rd)}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -44,7 +44,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSW {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: imm[4:0] :: 7'b0100111;
-            assembly: "f {rs2}, {imm}({name(rs1)])";
+            assembly: "{fname(rs2)}, {imm}({name(rs1)])";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 MEM[offs] = (unsigned<32>)F[rs2];
@@ -53,7 +53,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMADD_S {
             encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, {name(rd)}, {fname(rs1)}, {fname(rs2)}, {fname(rs3)}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f + F[rs3]f;
                 if (FLEN == 32)
@@ -69,7 +69,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMSUB_S {
             encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000111;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, {name(rd)}, {fname(rs1)}, {fname(rs2)}, {fname(rs3)}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f - F[rs3]f;
                 if (FLEN == 32)
@@ -85,7 +85,7 @@ InstructionSet RV32F extends Zicsr {
 
         FNMADD_S {
             encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001111;
-            assembly: "{name(rm)}, name(rd), f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, name(rd), {fname(rs1)}, {fname(rs2)}, {fname(rs3)}";
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f + F[rs3]f;
                 if (FLEN == 32)
@@ -104,7 +104,7 @@ InstructionSet RV32F extends Zicsr {
 
         FNMSUB_S {
             encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, {name(rd)}, {fname(rs1)}, {fname(rs2)}, {fname(rs3)}";
             behavior: {
             //F[rd]f = -F[rs1]f * F[rs2]f - F[rs3]f;
                 if (FLEN == 32)
@@ -123,7 +123,7 @@ InstructionSet RV32F extends Zicsr {
 
         FADD_S {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fadd.s", "{name(rm)}, f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fadd.s", "{name(rm)}, {fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
                 if (FLEN == 32)
@@ -141,7 +141,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSUB_S {
             encoding: 7'b0000100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fsub.s", "{name(rm)}, f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fsub.s", "{name(rm)}, {fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
                 if (FLEN == 32)
@@ -159,7 +159,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMUL_S {
             encoding: 7'b0001000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fmul.s", "{name(rm)}, f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fmul.s", "{name(rm)}, {fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
                 if (FLEN == 32)
@@ -177,7 +177,7 @@ InstructionSet RV32F extends Zicsr {
 
         FDIV_S {
             encoding: 7'b0001100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fdiv.s", "{name(rm)}, f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fdiv.s", "{name(rm)}, {fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
                 if (FLEN == 32)
@@ -195,7 +195,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSQRT_S {
             encoding: 7'b0101100 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fsqrt.s", "{name(rm)}, f {rd}, f {rs1}"};
+            assembly: {"fsqrt.s", "{name(rm)}, {fname(rd)}, {fname(rs1)}"};
             behavior: {
                 //F[rd]f = sqrt(F[rs1]f);
                 if (FLEN == 32)
@@ -212,7 +212,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJ_S {
             encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fsgnj.s", "f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fsgnj.s", "{fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = F[rs2][31:31] :: F[rs1][30:0];
@@ -227,7 +227,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJN_S {
             encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fsgnjn.s", "f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fsgnjn.s", "{fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = ~F[rs2][31:31] :: F[rs1][30:0];
@@ -242,7 +242,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJX_S {
             encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fsgnjx.s", "f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fsgnjx.s", "{fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = F[rs1] ^ (F[rs2] & 0x80000000);
@@ -257,7 +257,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMIN_S {
             encoding: 7'b0010100 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fmin.s", "f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fmin.s", "{fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
                 if (FLEN == 32)
@@ -275,7 +275,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMAX_S {
             encoding: 7'b0010100 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fmax.s", "f {rd}, f {rs1}, f {rs2}"};
+            assembly: {"fmax.s", "{fname(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
                 if (FLEN == 32)
@@ -293,7 +293,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_W_S {
             encoding: 7'b1100000 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.w.s", "{name(rm)}, {name(rd)}, f {rs1}"};
+            assembly: {"fcvt.w.s", "{name(rm)}, {name(rd)}, {fname(rs1)}"};
             behavior: {
                 signed<32> res = 0;
                 if (FLEN == 32)
@@ -310,7 +310,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_WU_S {
             encoding: 7'b1100000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.wu.s", "{name(rm)}, {name(rd)}, f {rs1}"};
+            assembly: {"fcvt.wu.s", "{name(rm)}, {name(rd)}, {fname(rs1)}"};
             behavior: {
                 //FIXME: according to the spec it should be zero-extended not sign extended
                 unsigned<32> res = 0;
@@ -328,7 +328,7 @@ InstructionSet RV32F extends Zicsr {
 
         FEQ_S {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly: {"feq.s", "{name(rd)}, f {rs1}, f {rs2}"};
+            assembly: {"feq.s", "{name(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -346,7 +346,7 @@ InstructionSet RV32F extends Zicsr {
 
         FLT_S {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: {"flt.s", "{name(rd)}, f {rs1}, f {rs2}"};
+            assembly: {"flt.s", "{name(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -364,7 +364,7 @@ InstructionSet RV32F extends Zicsr {
 
         FLE_S {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fle.s", "{name(rd)}, f {rs1}, f {rs2}"};
+            assembly: {"fle.s", "{name(rd)}, {fname(rs1)}, {fname(rs2)}"};
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -382,7 +382,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCLASS_S {
             encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fclass.s", "{name(rd)}, f {rs1}"};
+            assembly: {"fclass.s", "{name(rd)}, {fname(rs1)}"};
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -395,7 +395,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_S_W {
             encoding: 7'b1101000 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.s.w", "{name(rm)}, f {rd}, {name(rs1)}"};
+            assembly: {"fcvt.s.w", "{name(rm)}, {fname(rd)}, {name(rs1)}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = fcvt_s((unsigned)X[rs1 % RFS], 2, rm);
@@ -408,7 +408,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_S_WU {
             encoding: 7'b1101000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.s.wu", "{name(rm)}, f {rd}, {name(rs1)}"};
+            assembly: {"fcvt.s.wu", "{name(rm)}, {fname(rd)}, {name(rs1)}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = fcvt_s((unsigned)X[rs1 % RFS], 3, rm);
@@ -421,7 +421,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMV_X_W {
             encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fmv.x.w", "{name(rd)}, f {rs1}"};
+            assembly: {"fmv.x.w", "{name(rd)}, {fname(rs1)}"};
             behavior: {
                 if ((rd % RFS) != 0) X[rd % RFS] = F[rs1];
             }
@@ -429,7 +429,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMV_W_X {
             encoding: 7'b1111000 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: {"fmv.w.x", "f {rd}, {name(rs1)}"};
+            assembly: {"fmv.w.x", "{fname(rd)}, {name(rs1)}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = X[rs1 % RFS];
@@ -445,7 +445,7 @@ InstructionSet RV64F extends RV32F {
     instructions {
         FCVT_L_S { // fp to 64bit signed integer
             encoding: 7'b1100000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.l.s", "{name(rm)}, {name(rd)}, f {rs1}"};
+            assembly: {"fcvt.l.s", "{name(rm)}, {name(rd)}, {fname(rs1)}"};
             behavior: {
                 signed<64> res = fcvt_32_64(unbox_s(F[rs1]), 0, rm);
                 if ((rd % RFS) != 0) X[rd % RFS] = res;
@@ -456,7 +456,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_LU_S { // fp to 64bit unsigned integer
             encoding: 7'b1100000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.lu.s", "{name(rm)}, {name(rd)}, f {rs1}"};
+            assembly: {"fcvt.lu.s", "{name(rm)}, {name(rd)}, {fname(rs1)}"};
             behavior: {
                 unsigned<64> res = fcvt_32_64(unbox_s(F[rs1]), 1, rm);
                 if ((rd % RFS) != 0) X[rd % RFS] = res;
@@ -467,7 +467,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_S_L { // 64bit signed int to to fp
             encoding: 7'b1101000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.s.l", "{name(rm)}, f {rd}, {name(rs1)}"};
+            assembly: {"fcvt.s.l", "{name(rm)}, {fname(rd)}, {name(rs1)}"};
             behavior: {
                 unsigned<32> res = fcvt_64_32(X[rs1 % RFS], 2, rm);
                 if (FLEN == 32)
@@ -480,7 +480,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_S_LU { // 64bit unsigned int to to fp
             encoding: 7'b1101000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: {"fcvt.s.lu", "{name(rm)}, f {rd}, {name(rs1)}"};
+            assembly: {"fcvt.s.lu", "{name(rm)}, {fname(rd)}, {name(rs1)}"};
             behavior: {
                 unsigned<32> res = fcvt_64_32(X[rs1 % RFS], 3, rm);
                 if (FLEN == 32)

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -30,7 +30,7 @@ InstructionSet RV32F extends Zicsr {
     instructions {
         FLW {
             encoding: imm[11:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0000111;
-            assembly:"f {rd}, {imm}({name(rs1)})";
+            assembly: "f {rd}, {imm}({name(rs1)})";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 unsigned<32> res = (unsigned<32>)MEM[offs];
@@ -44,7 +44,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSW {
             encoding: imm[11:5] :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: imm[4:0] :: 7'b0100111;
-            assembly:"f {rs2}, {imm}({name(rs1)])";
+            assembly: "f {rs2}, {imm}({name(rs1)])";
             behavior: {
                 unsigned<XLEN> offs = X[rs1 % RFS] + (signed<12>)imm;
                 MEM[offs] = (unsigned<32>)F[rs2];
@@ -53,7 +53,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMADD_S {
             encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f + F[rs3]f;
                 if (FLEN == 32)
@@ -69,7 +69,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMSUB_S {
             encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1000111;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = F[rs1]f * F[rs2]f - F[rs3]f;
                 if (FLEN == 32)
@@ -85,7 +85,7 @@ InstructionSet RV32F extends Zicsr {
 
         FNMADD_S {
             encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001111;
-            assembly:"{name(rm)}, name(rd), f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, name(rd), f {rs1}, f {rs2}, f {rs3}";
             behavior: {
                 //F[rd]f = -F[rs1]f * F[rs2]f + F[rs3]f;
                 if (FLEN == 32)
@@ -104,7 +104,7 @@ InstructionSet RV32F extends Zicsr {
 
         FNMSUB_S {
             encoding: rs3[4:0] :: 2'b00 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1001011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}, f {rs2}, f {rs3}";
             behavior: {
             //F[rd]f = -F[rs1]f * F[rs2]f - F[rs3]f;
                 if (FLEN == 32)
@@ -123,7 +123,7 @@ InstructionSet RV32F extends Zicsr {
 
         FADD_S {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly: "{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
                 if (FLEN == 32)
@@ -141,7 +141,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSUB_S {
             encoding: 7'b0000100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly: "{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
                 if (FLEN == 32)
@@ -159,7 +159,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMUL_S {
             encoding: 7'b0001000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly: "{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
                 if (FLEN == 32)
@@ -177,7 +177,7 @@ InstructionSet RV32F extends Zicsr {
 
         FDIV_S {
             encoding: 7'b0001100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly: "{name(rm)}, f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
                 if (FLEN == 32)
@@ -195,7 +195,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSQRT_S {
             encoding: 7'b0101100 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, f {rs1}";
+            assembly: "{name(rm)}, f {rd}, f {rs1}";
             behavior: {
                 //F[rd]f = sqrt(F[rs1]f);
                 if (FLEN == 32)
@@ -212,7 +212,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJ_S {
             encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, f {rs1}, f {rs2}";
+            assembly: "f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = F[rs2][31:31] :: F[rs1][30:0];
@@ -227,7 +227,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJN_S {
             encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, f {rs1}, f {rs2}";
+            assembly: "f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = ~F[rs2][31:31] :: F[rs1][30:0];
@@ -242,7 +242,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJX_S {
             encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, f {rs1}, f {rs2}";
+            assembly: "f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = F[rs1] ^ (F[rs2] & 0x80000000);
@@ -257,7 +257,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMIN_S {
             encoding: 7'b0010100 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, f {rs1}, f {rs2}";
+            assembly: "f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
                 if (FLEN == 32)
@@ -275,7 +275,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMAX_S {
             encoding: 7'b0010100 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, f {rs1}, f {rs2}";
+            assembly: "f {rd}, f {rs1}, f {rs2}";
             behavior: {
                 //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
                 if (FLEN == 32)
@@ -293,7 +293,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_W_S {
             encoding: 7'b1100000 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 signed<32> res = 0;
                 if (FLEN == 32)
@@ -310,7 +310,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_WU_S {
             encoding: 7'b1100000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 //FIXME: according to the spec it should be zero-extended not sign extended
                 unsigned<32> res = 0;
@@ -328,7 +328,7 @@ InstructionSet RV32F extends Zicsr {
 
         FEQ_S {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly: "{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -346,7 +346,7 @@ InstructionSet RV32F extends Zicsr {
 
         FLT_S {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly: "{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -364,7 +364,7 @@ InstructionSet RV32F extends Zicsr {
 
         FLE_S {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rd)}, f {rs1}, f {rs2}";
+            assembly: "{name(rd)}, f {rs1}, f {rs2}";
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -382,7 +382,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCLASS_S {
             encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rd)}, f {rs1}";
+            assembly: "{name(rd)}, f {rs1}";
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -395,7 +395,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_S_W {
             encoding: 7'b1101000 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = fcvt_s((unsigned)X[rs1 % RFS], 2, rm);
@@ -408,7 +408,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_S_WU {
             encoding: 7'b1101000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = fcvt_s((unsigned)X[rs1 % RFS], 3, rm);
@@ -421,7 +421,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMV_X_W {
             encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rd)}, f {rs1}";
+            assembly: "{name(rd)}, f {rs1}";
             behavior: {
                 if ((rd % RFS) != 0) X[rd % RFS] = F[rs1];
             }
@@ -429,7 +429,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMV_W_X {
             encoding: 7'b1111000 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly:"f {rd}, {name(rs1)}";
+            assembly: "f {rd}, {name(rs1)}";
             behavior: {
                 if (FLEN == 32)
                     F[rd] = X[rs1 % RFS];
@@ -445,7 +445,7 @@ InstructionSet RV64F extends RV32F {
     instructions {
         FCVT_L_S { // fp to 64bit signed integer
             encoding: 7'b1100000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 signed<64> res = fcvt_32_64(unbox_s(F[rs1]), 0, rm);
                 if ((rd % RFS) != 0) X[rd % RFS] = res;
@@ -456,7 +456,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_LU_S { // fp to 64bit unsigned integer
             encoding: 7'b1100000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
             behavior: {
                 unsigned<64> res = fcvt_32_64(unbox_s(F[rs1]), 1, rm);
                 if ((rd % RFS) != 0) X[rd % RFS] = res;
@@ -467,7 +467,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_S_L { // 64bit signed int to to fp
             encoding: 7'b1101000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<32> res = fcvt_64_32(X[rs1 % RFS], 2, rm);
                 if (FLEN == 32)
@@ -480,7 +480,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_S_LU { // 64bit unsigned int to to fp
             encoding: 7'b1101000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly:"{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
             behavior: {
                 unsigned<32> res = fcvt_64_32(X[rs1 % RFS], 3, rm);
                 if (FLEN == 32)

--- a/RVF.core_desc
+++ b/RVF.core_desc
@@ -123,7 +123,7 @@ InstructionSet RV32F extends Zicsr {
 
         FADD_S {
             encoding: 7'b0000000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fadd.s", "{name(rm)}, f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 // F[rd]f = F[rs1]f + F[rs2]f;
                 if (FLEN == 32)
@@ -141,7 +141,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSUB_S {
             encoding: 7'b0000100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fsub.s", "{name(rm)}, f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 // F[rd]f = F[rs1]f - F[rs2]f;
                 if (FLEN == 32)
@@ -159,7 +159,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMUL_S {
             encoding: 7'b0001000 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fmul.s", "{name(rm)}, f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 // F[rd]f = F[rs1]f * F[rs2]f;
                 if (FLEN == 32)
@@ -177,7 +177,7 @@ InstructionSet RV32F extends Zicsr {
 
         FDIV_S {
             encoding: 7'b0001100 :: rs2[4:0] :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fdiv.s", "{name(rm)}, f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 // F[rd]f = F[rs1]f / F[rs2]f;
                 if (FLEN == 32)
@@ -195,7 +195,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSQRT_S {
             encoding: 7'b0101100 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, f {rs1}";
+            assembly: {"fsqrt.s", "{name(rm)}, f {rd}, f {rs1}"};
             behavior: {
                 //F[rd]f = sqrt(F[rs1]f);
                 if (FLEN == 32)
@@ -212,7 +212,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJ_S {
             encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fsgnj.s", "f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = F[rs2][31:31] :: F[rs1][30:0];
@@ -227,7 +227,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJN_S {
             encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fsgnjn.s", "f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = ~F[rs2][31:31] :: F[rs1][30:0];
@@ -242,7 +242,7 @@ InstructionSet RV32F extends Zicsr {
 
         FSGNJX_S {
             encoding: 7'b0010000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fsgnjx.s", "f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = F[rs1] ^ (F[rs2] & 0x80000000);
@@ -257,7 +257,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMIN_S {
             encoding: 7'b0010100 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fmin.s", "f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 //F[rd]f = choose(F[rs1]f<F[rs2]f, F[rs1]f, F[rs2]f);
                 if (FLEN == 32)
@@ -275,7 +275,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMAX_S {
             encoding: 7'b0010100 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, f {rs1}, f {rs2}";
+            assembly: {"fmax.s", "f {rd}, f {rs1}, f {rs2}"};
             behavior: {
                 //F[rd]f = choose(F[rs1]f>F[rs2]f, F[rs1]f, F[rs2]f);
                 if (FLEN == 32)
@@ -293,7 +293,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_W_S {
             encoding: 7'b1100000 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: {"fcvt.w.s", "{name(rm)}, {name(rd)}, f {rs1}"};
             behavior: {
                 signed<32> res = 0;
                 if (FLEN == 32)
@@ -310,7 +310,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_WU_S {
             encoding: 7'b1100000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: {"fcvt.wu.s", "{name(rm)}, {name(rd)}, f {rs1}"};
             behavior: {
                 //FIXME: according to the spec it should be zero-extended not sign extended
                 unsigned<32> res = 0;
@@ -328,7 +328,7 @@ InstructionSet RV32F extends Zicsr {
 
         FEQ_S {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rd)}, f {rs1}, f {rs2}";
+            assembly: {"feq.s", "{name(rd)}, f {rs1}, f {rs2}"};
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -346,7 +346,7 @@ InstructionSet RV32F extends Zicsr {
 
         FLT_S {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rd)}, f {rs1}, f {rs2}";
+            assembly: {"flt.s", "{name(rd)}, f {rs1}, f {rs2}"};
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -364,7 +364,7 @@ InstructionSet RV32F extends Zicsr {
 
         FLE_S {
             encoding: 7'b1010000 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rd)}, f {rs1}, f {rs2}";
+            assembly: {"fle.s", "{name(rd)}, f {rs1}, f {rs2}"};
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -382,7 +382,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCLASS_S {
             encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rd)}, f {rs1}";
+            assembly: {"fclass.s", "{name(rd)}, f {rs1}"};
             behavior: {
                 unsigned<32> res = 0;
                 if (FLEN == 32)
@@ -395,7 +395,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_S_W {
             encoding: 7'b1101000 :: 5'b00000 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: {"fcvt.s.w", "{name(rm)}, f {rd}, {name(rs1)}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = fcvt_s((unsigned)X[rs1 % RFS], 2, rm);
@@ -408,7 +408,7 @@ InstructionSet RV32F extends Zicsr {
 
         FCVT_S_WU {
             encoding: 7'b1101000 :: 5'b00001 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: {"fcvt.s.wu", "{name(rm)}, f {rd}, {name(rs1)}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = fcvt_s((unsigned)X[rs1 % RFS], 3, rm);
@@ -421,7 +421,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMV_X_W {
             encoding: 7'b1110000 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rd)}, f {rs1}";
+            assembly: {"fmv.x.w", "{name(rd)}, f {rs1}"};
             behavior: {
                 if ((rd % RFS) != 0) X[rd % RFS] = F[rs1];
             }
@@ -429,7 +429,7 @@ InstructionSet RV32F extends Zicsr {
 
         FMV_W_X {
             encoding: 7'b1111000 :: 5'b00000 :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b1010011;
-            assembly: "f {rd}, {name(rs1)}";
+            assembly: {"fmv.w.x", "f {rd}, {name(rs1)}"};
             behavior: {
                 if (FLEN == 32)
                     F[rd] = X[rs1 % RFS];
@@ -445,7 +445,7 @@ InstructionSet RV64F extends RV32F {
     instructions {
         FCVT_L_S { // fp to 64bit signed integer
             encoding: 7'b1100000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: {"fcvt.l.s", "{name(rm)}, {name(rd)}, f {rs1}"};
             behavior: {
                 signed<64> res = fcvt_32_64(unbox_s(F[rs1]), 0, rm);
                 if ((rd % RFS) != 0) X[rd % RFS] = res;
@@ -456,7 +456,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_LU_S { // fp to 64bit unsigned integer
             encoding: 7'b1100000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, {name(rd)}, f {rs1}";
+            assembly: {"fcvt.lu.s", "{name(rm)}, {name(rd)}, f {rs1}"};
             behavior: {
                 unsigned<64> res = fcvt_32_64(unbox_s(F[rs1]), 1, rm);
                 if ((rd % RFS) != 0) X[rd % RFS] = res;
@@ -467,7 +467,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_S_L { // 64bit signed int to to fp
             encoding: 7'b1101000 :: 5'b00010 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: {"fcvt.s.l", "{name(rm)}, f {rd}, {name(rs1)}"};
             behavior: {
                 unsigned<32> res = fcvt_64_32(X[rs1 % RFS], 2, rm);
                 if (FLEN == 32)
@@ -480,7 +480,7 @@ InstructionSet RV64F extends RV32F {
 
         FCVT_S_LU { // 64bit unsigned int to to fp
             encoding: 7'b1101000 :: 5'b00011 :: rs1[4:0] :: rm[2:0] :: rd[4:0] :: 7'b1010011;
-            assembly: "{name(rm)}, f {rd}, {name(rs1)}";
+            assembly: {"fcvt.s.lu", "{name(rm)}, f {rd}, {name(rs1)}"};
             behavior: {
                 unsigned<32> res = fcvt_64_32(X[rs1 % RFS], 3, rm);
                 if (FLEN == 32)

--- a/RVM.core_desc
+++ b/RVM.core_desc
@@ -8,7 +8,7 @@ InstructionSet RV32M extends RISCVBase {
     instructions {
         MUL {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else {
                 signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
                 if(rd!=0) X[rd] = (unsigned<XLEN>)res;
@@ -17,7 +17,7 @@ InstructionSet RV32M extends RISCVBase {
 
         MULH {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b001 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else {
                 signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (signed<MUL_LEN>)(signed)X[rs2];
                 if(rd!=0) X[rd] = (unsigned<XLEN>)(res >> XLEN);
@@ -26,7 +26,7 @@ InstructionSet RV32M extends RISCVBase {
 
         MULHSU {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b010 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else {
                 signed<MUL_LEN> res = (signed<MUL_LEN>)(signed)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
                     if(rd!=0) X[rd] = (unsigned<XLEN>)(res >> XLEN);
@@ -35,7 +35,7 @@ InstructionSet RV32M extends RISCVBase {
 
         MULHU {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b011 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else {
                 unsigned<MUL_LEN> res = (unsigned<MUL_LEN>)X[rs1] * (unsigned<MUL_LEN>)X[rs2];
                 if(rd!=0) X[rd] = (unsigned<XLEN>)(res >> XLEN);
@@ -44,7 +44,7 @@ InstructionSet RV32M extends RISCVBase {
 
         DIV {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else  {
                 signed<XLEN> dividend = (signed<XLEN>)X[rs1];
                 signed<XLEN> divisor = (signed<XLEN>)X[rs2];
@@ -63,7 +63,7 @@ InstructionSet RV32M extends RISCVBase {
 
         DIVU {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else  {
                 if (X[rs2] != 0) {
                     if(rd!=0) X[rd] = X[rs1] / X[rs2];
@@ -74,7 +74,7 @@ InstructionSet RV32M extends RISCVBase {
 
         REM {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else  {
                 if (X[rs2] != 0) {
                     unsigned<XLEN> MMIN = 1<<(XLEN-1);
@@ -90,7 +90,7 @@ InstructionSet RV32M extends RISCVBase {
 
         REMU {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0110011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else {
                 if (X[rs2] != 0) {
                     if(rd!=0) X[rd] = X[rs1] % X[rs2];
@@ -106,7 +106,7 @@ InstructionSet RV64M extends RV32M {
     instructions {
         MULW {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b000 :: rd[4:0] :: 7'b0111011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else   {
                 if(rd!=0) X[rd] = (signed<64>)((signed<32>)X[rs1] * (signed<32>)X[rs2]);
             }
@@ -114,7 +114,7 @@ InstructionSet RV64M extends RV32M {
 
         DIVW {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b100 :: rd[4:0] :: 7'b0111011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else  {
                 signed<32> dividend = (signed<32>)X[rs1];
                 signed<32> divisor = (signed<32>)X[rs2];
@@ -132,7 +132,7 @@ InstructionSet RV64M extends RV32M {
 
         DIVUW {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b101 :: rd[4:0] :: 7'b0111011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else  {
                 unsigned<32> dividend = (unsigned<32>)X[rs1];
                 unsigned<32> divisor = (unsigned<32>)X[rs2];
@@ -145,7 +145,7 @@ InstructionSet RV64M extends RV32M {
 
         REMW {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b110 :: rd[4:0] :: 7'b0111011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else {
                 if (((signed<32>)X[rs2]) != 0) {
                     signed<32> SMIN = 1<<31;
@@ -161,7 +161,7 @@ InstructionSet RV64M extends RV32M {
 
         REMUW {
             encoding: 7'b0000001 :: rs2[4:0] :: rs1[4:0] :: 3'b111 :: rd[4:0] :: 7'b0111011;
-            assembly:"{name(rd)}, {name(rs1)}, {name(rs2)}";
+            assembly: "{name(rd)}, {name(rs1)}, {name(rs2)}";
             behavior: if(rd >=RFS || rs1>=RFS || rs2>=RFS) raise(0, 2); else  {
                 if ((unsigned<32>)X[rs2] != 0) {
                     if(rd!=0) X[rd] = (unsigned<XLEN>)((unsigned<32>)X[rs1] % (unsigned<32>)X[rs2]);


### PR DESCRIPTION
### Changes
- Add missing space after `assembly:` (Diff: https://github.com/Minres/RISCV_ISA_CoreDSL/commit/793b18a0a283fde033d14cc2f8804e1594f8f6dd)
  - Should be trivial since it's just whitespace
- Add mnemonics if required (Diff: https://github.com/Minres/RISCV_ISA_CoreDSL/commit/c380c3d6f204bf2efb870ef49da8efcfff263fcd) 
- Fix typos in some assembly args strings (Diff: https://github.com/Minres/RISCV_ISA_CoreDSL/commit/f0781c4aca13b79675c67dc83449cf72f27963a7)
- Use `{fname(rd)}` instead of `f {rd}` for float registers in assembly args (Diff: https://github.com/Minres/RISCV_ISA_CoreDSL/commit/c16a4cc32d821de6797939f14493f7ae177bdd7b)
  - Not sure if this might make downstream tools/backends